### PR TITLE
Allowing multiple listeners per filter type.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "augur.js",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Augur JavaScript API",
   "main": "src/index.js",
   "scripts": {

--- a/src/filters.js
+++ b/src/filters.js
@@ -434,7 +434,7 @@ module.exports = function () {
                 run = async.series;
             }
             async.forEachOfSeries(cb, function (callback, label, next) {
-                if (self.filter[label].id === null && callback) {
+                if (self.filter[label] && callback) {
                     switch (label) {
                     case "contracts":
                         self.start_contracts_listener(function () {
@@ -456,6 +456,8 @@ module.exports = function () {
                             next(null, [label, self.filter[label].id]);
                         });
                     }
+                }else{
+                    next(null, null);
                 }
             }, function (err) {
                 if (err) console.error(err);

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ var modules = [
 ];
 
 function Augur() {
-    this.version = "1.7.1";
+    this.version = "1.7.2";
 
     this.options = {debug: {broadcast: false, fallback: false}};
     this.protocol = NODE_JS || document.location.protocol;


### PR DESCRIPTION
@tinybike how do you feel about this change to address #104 that I filed a little earlier?

This does 2 things: 
Allows multiple functions to be registered for a given event. So If I do 

```
augur.filters.listen({
    marketCreated: function1
});
augur.filters.listen({
    marketCreated: function2
});
```
both function 1 and 2 will be registered. Previously if you tried to do this listen just hangs since `next` never gets called and the async.forEachOfSeries completion callback never gets fired.

This also fixes another bug I found where if you do
```
augur.filters.listen({
    foo: function1
});
```
listen hangs forever, again because foo isn't in self.filter and `next` never gets called. With this fix foo just gets ignored.
