### PR TITLE
594 fix cache node fallback

### DIFF
--- a/src/modules/compositeGetters.js
+++ b/src/modules/compositeGetters.js
@@ -71,11 +71,9 @@ module.exports = {
             return this.loadMarketsHelper(branchID, chunkSize, isDesc, chunkCB);
         }
         this.augurNode.getMarketsInfo(branchID, function (err, result) {
-						console.log(err);
-						if (typeof result === 'string')
-							console.log(result.charAt(0));
             if (err) {
                 console.warn("cache node getMarketsInfo failed:", err);
+								// Abandon the use of cache nodes since there was a connection issue.
 								self.augurNode.nodes = [];
                 // fallback to loading in batches from chain
                 return self.loadMarketsHelper(branchID, chunkSize, isDesc, chunkCB);

--- a/src/modules/compositeGetters.js
+++ b/src/modules/compositeGetters.js
@@ -73,7 +73,7 @@ module.exports = {
         this.augurNode.getMarketsInfo(branchID, function (err, result) {
             if (err) {
                 console.warn("cache node getMarketsInfo failed:", err);
-
+								self.augurNode.nodes = [];
                 // fallback to loading in batches from chain
                 return self.loadMarketsHelper(branchID, chunkSize, isDesc, chunkCB);
             }

--- a/src/modules/compositeGetters.js
+++ b/src/modules/compositeGetters.js
@@ -71,6 +71,9 @@ module.exports = {
             return this.loadMarketsHelper(branchID, chunkSize, isDesc, chunkCB);
         }
         this.augurNode.getMarketsInfo(branchID, function (err, result) {
+						console.log(err);
+						if (typeof result === 'string')
+							console.log(result.charAt(0));
             if (err) {
                 console.warn("cache node getMarketsInfo failed:", err);
 								self.augurNode.nodes = [];


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/594/fix-cache-node-fallback

This change simply empties the `augurNodes.nodes` array if there is an error connecting to a cache node. This will stop the code from retrying the cache node since it doesn't have any to check for anymore and fall back to the hosted node connection to load markets in chunks as expected. 