### PR TITLE
Removes timeout from `getMarketInfo`.

### DIFF
--- a/src/modules/compositeGetters.js
+++ b/src/modules/compositeGetters.js
@@ -336,7 +336,6 @@ module.exports = {
     volumeMax = volumeMax || 0;
     tx = clone(this.tx.CompositeGetters.getMarketsInfo);
     tx.params = [branch, offset, numMarketsToLoad, volumeMin, volumeMax];
-    tx.timeout = 240000;
     return this.fire(tx, callback, this.parseMarketsInfo, branch);
   }
 };


### PR DESCRIPTION
This is not currently supported by ethrpc and because it is on the transaction it breaks when communicating with ethereum nodes that are strict about the payloads they receive (e.g., Parity).