### PR TITLE
Bugfixes found while trying to get Augur working with Parity PoA chain

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,11 +74,8 @@ function Augur() {
   this.abi = require("augur-abi");
   this.constants = require("./constants");
   this.utils = require("./utilities");
-  this.rpc = require("ethrpc");
   this.subscriptionsSupported = false;
-  this.errors = this.rpc.errors;
-  this.abi.debug = this.options.debug.abi;
-  this.rpc.debug = this.options.debug;
+  this.errors = require("ethrpc").errors;
 
   // Load submodules
   for (i = 0, len = modules.length; i < len; ++i) {

--- a/src/modules/compositeGetters.js
+++ b/src/modules/compositeGetters.js
@@ -44,7 +44,7 @@ module.exports = {
   // load each batch of marketdata sequentially and recursively until complete
   loadNextMarketsBatch: function (branchID, startIndex, chunkSize, numMarkets, isDesc, volumeMin, volumeMax, chunkCB, nextPass) {
     var self = this;
-    var numMarketsToLoad = isDesc ? Math.min(chunkSize, startIndex) : Math.min(chunkSize, numMarkets - startIndex);
+    var numMarketsToLoad = Math.min(chunkSize, numMarkets - startIndex);
     if (numMarketsToLoad > 0) {
       this.getMarketsInfo({
         branch: branchID,

--- a/src/modules/logs.js
+++ b/src/modules/logs.js
@@ -103,8 +103,7 @@ module.exports = {
       fromBlock: params.fromBlock || constants.GET_LOGS_DEFAULT_FROM_BLOCK,
       toBlock: params.toBlock || constants.GET_LOGS_DEFAULT_TO_BLOCK,
       address: this.contracts[event.contract],
-      topics: this.buildTopicsList(event, params),
-      timeout: constants.GET_LOGS_TIMEOUT
+      topics: this.buildTopicsList(event, params)
     };
   },
 
@@ -326,8 +325,7 @@ module.exports = {
         fromBlock: options.fromBlock || "0x1",
         toBlock: options.toBlock || "latest",
         address: this.contracts.Trade,
-        topics: topics,
-        timeout: constants.GET_LOGS_TIMEOUT
+        topics: topics
       };
       if (!utils.is_function(callback)) return this.rpc.getLogs(filter);
       this.rpc.getLogs(filter, function (logs) {
@@ -393,8 +391,7 @@ module.exports = {
           abi.format_int256(account),
           market,
           typeCode
-        ],
-        timeout: constants.GET_LOGS_TIMEOUT
+        ]
       };
       if (!utils.is_function(callback)) return this.rpc.getLogs(filter);
       this.rpc.getLogs(filter, function (logs) {

--- a/test/unit/core/logs.js
+++ b/test/unit/core/logs.js
@@ -494,8 +494,7 @@ describe("logs.parametrizeFilter", function() {
         toBlock: augur.constants.GET_LOGS_DEFAULT_TO_BLOCK,
         address: augur.contracts.CompleteSets,
         topics: [augur.api.events.completeSets_logReturn.signature, '0x0000000000000000000000000000000000000000000000000000000000000050', '0x00000000000000000000000000000000000000000000000000000000000000a1',
-        '0x0000000000000000000000000000000000000000000000000000000000000002'],
-        timeout: augur.constants.GET_LOGS_TIMEOUT,
+        '0x0000000000000000000000000000000000000000000000000000000000000002']
       });
     }
   });
@@ -511,8 +510,7 @@ describe("logs.parametrizeFilter", function() {
         toBlock: '0x0b2',
         address: augur.contracts.CompleteSets,
         topics: [augur.api.events.completeSets_logReturn.signature, '0x0000000000000000000000000000000000000000000000000000000000000050', '0x00000000000000000000000000000000000000000000000000000000000000a1',
-        '0x0000000000000000000000000000000000000000000000000000000000000002'],
-        timeout: augur.constants.GET_LOGS_TIMEOUT,
+        '0x0000000000000000000000000000000000000000000000000000000000000002']
       });
     }
   });
@@ -900,8 +898,7 @@ describe("logs.getFilteredLogs", function() {
         topics: [augur.api.events['log_add_tx'].signature,
           null,
           null
-        ],
-        timeout: 480000
+        ]
       });
     }
   });
@@ -926,8 +923,7 @@ describe("logs.getFilteredLogs", function() {
         topics: [augur.api.events['log_add_tx'].signature,
           null,
           null
-        ],
-        timeout: 480000
+        ]
       });
     }
   });
@@ -948,8 +944,7 @@ describe("logs.getFilteredLogs", function() {
         topics: [augur.api.events['log_add_tx'].signature,
           null,
           null
-        ],
-        timeout: 480000
+        ]
       });
     },
     getLogs: function(filters, cb) {
@@ -1878,8 +1873,7 @@ describe("logs.getShortSellLogs", function() {
          fromBlock: augur.constants.GET_LOGS_DEFAULT_FROM_BLOCK,
          toBlock: augur.constants.GET_LOGS_DEFAULT_TO_BLOCK,
          address: augur.contracts.Trade,
-         topics: [augur.api.events.log_short_fill_tx.signature, null, '0x00000000000000000000000002a32d32ca2b37495839dd932c9e92fea10cba12', null],
-         timeout: augur.constants.GET_LOGS_TIMEOUT
+         topics: [augur.api.events.log_short_fill_tx.signature, null, '0x00000000000000000000000002a32d32ca2b37495839dd932c9e92fea10cba12', null]
        });
      }
    });
@@ -1895,8 +1889,7 @@ describe("logs.getShortSellLogs", function() {
          fromBlock: '0x0b1',
          toBlock: '0x0c1',
          address: augur.contracts.Trade,
-         topics: [augur.api.events.log_short_fill_tx.signature, '0x00000000000000000000000000000000000000000000000000000000000000a1', '0x00000000000000000000000002a32d32ca2b37495839dd932c9e92fea10cba12', null],
-         timeout: augur.constants.GET_LOGS_TIMEOUT
+         topics: [augur.api.events.log_short_fill_tx.signature, '0x00000000000000000000000000000000000000000000000000000000000000a1', '0x00000000000000000000000002a32d32ca2b37495839dd932c9e92fea10cba12', null]
        });
      }
    });
@@ -1911,8 +1904,7 @@ describe("logs.getShortSellLogs", function() {
          fromBlock: '0x0b1',
          toBlock: '0x0c1',
          address: augur.contracts.Trade,
-         topics: [augur.api.events.log_short_fill_tx.signature, '0x00000000000000000000000000000000000000000000000000000000000000a1', null, '0x00000000000000000000000002a32d32ca2b37495839dd932c9e92fea10cba12'],
-         timeout: augur.constants.GET_LOGS_TIMEOUT
+         topics: [augur.api.events.log_short_fill_tx.signature, '0x00000000000000000000000000000000000000000000000000000000000000a1', null, '0x00000000000000000000000002a32d32ca2b37495839dd932c9e92fea10cba12']
        });
      },
      getLogs: function(filter, cb) {
@@ -1969,8 +1961,7 @@ describe("logs.getShortSellLogs", function() {
          fromBlock: augur.constants.GET_LOGS_DEFAULT_FROM_BLOCK,
          toBlock: augur.constants.GET_LOGS_DEFAULT_TO_BLOCK,
          address: augur.contracts.Trade,
-         topics: [augur.api.events.log_short_fill_tx.signature, null, '0x00000000000000000000000002a32d32ca2b37495839dd932c9e92fea10cba12', null],
-         timeout: augur.constants.GET_LOGS_TIMEOUT
+         topics: [augur.api.events.log_short_fill_tx.signature, null, '0x00000000000000000000000002a32d32ca2b37495839dd932c9e92fea10cba12', null]
        });
      },
      callback: undefined,
@@ -2258,8 +2249,7 @@ describe("logs.getCompleteSetsLogs", function() {
       		'0x00000000000000000000000000000000000000000000000000000deadbeef123',
       		null,
       		null
-      	],
-      	timeout: 480000
+      	]
       });
       if(utils.is_function(cb)) {
         return cb({ error: 999, message: 'Uh-Oh!' });
@@ -2293,8 +2283,7 @@ describe("logs.getCompleteSetsLogs", function() {
       		'0x00000000000000000000000000000000000000000000000000000deadbeef123',
       		'0x00000000000000000000000000000000000000000000000000000000000000a1',
       		null
-      	],
-      	timeout: 480000
+      	]
       });
       if(utils.is_function(cb)) {
         return cb([]);
@@ -2344,8 +2333,7 @@ describe("logs.getCompleteSetsLogs", function() {
       		'0x00000000000000000000000000000000000000000000000000000deadbeef123',
       		'0x00000000000000000000000000000000000000000000000000000000000000a1',
       		'0x0000000000000000000000000000000000000000000000000000000000000001'
-      	],
-      	timeout: 480000
+      	]
       });
       if(utils.is_function(cb)) {
         return cb([{


### PR DESCRIPTION
Fixes duplicate ethrpc inclusion:  ethrpc needs to come from `ethereumjs-connect`, otherwise you end up using/mutating a copy that is never connected and should never be used.

Removes timeout from getLogs object:  This is not used by ethrpc, and it is not cleared by ethrpc because it is on a nested object rather than the params array directly, and it causes problems in Parity since Parity doesn't like extraneous parameters.  Same fix as a previous issue with `timeout` being added to a sub-object.

Fixes a bug where the last chunk of markets wouldn't load:  `startIndex` for the last chunk worth of markets will always be 0.  If sort is descending, this will result in `numMarketsToLoad` being set to `0` which terminates the load prematurely.