### PR TITLE
Fix wrong # of shares being used in simulation

### DIFF
--- a/src/trading/simulation/simulate-sell.js
+++ b/src/trading/simulation/simulate-sell.js
@@ -28,7 +28,7 @@ function simulateSell(outcome, sharesToCover, shareBalances, tokenBalance, userA
     var simulatedTakeBidOrder = simulateTakeBidOrder(sharesToCover, minPrice, maxPrice, marketCreatorFeeRate, reportingFeeRate, shouldCollectReportingFees, matchingSortedBids, outcome, shareBalances);
     simulatedSell = sumSimulatedResults(simulatedSell, simulatedTakeBidOrder);
     if (simulatedTakeBidOrder.sharesToCover.gt(PRECISION.zero)) {
-      simulatedSell = sumSimulatedResults(simulatedSell, simulateMakeAskOrder(sharesToCover, price, maxPrice, outcome, shareBalances));
+      simulatedSell = sumSimulatedResults(simulatedSell, simulateMakeAskOrder(simulatedTakeBidOrder.sharesToCover, price, maxPrice, outcome, shareBalances));
     }
   }
 

--- a/test/unit/trading/simulation/simulate-sell.js
+++ b/test/unit/trading/simulation/simulate-sell.js
@@ -44,7 +44,7 @@ describe("trading/simulation/simulate-sell", function () {
         gasFees: ZERO,
         otherSharesDepleted: ZERO,
         sharesDepleted: ZERO,
-        tokensDepleted: new BigNumber("9", 10),
+        tokensDepleted: new BigNumber("0.9", 10),
         shareBalances: [ZERO, new BigNumber("5", 10)]
       });
     }
@@ -79,7 +79,7 @@ describe("trading/simulation/simulate-sell", function () {
         gasFees: ZERO,
         otherSharesDepleted: ZERO,
         sharesDepleted: ZERO,
-        tokensDepleted: new BigNumber("7", 10),
+        tokensDepleted: new BigNumber("0.7", 10),
         shareBalances: [ZERO, new BigNumber("5", 10)]
       });
     }
@@ -121,8 +121,8 @@ describe("trading/simulation/simulate-sell", function () {
         gasFees: ZERO,
         otherSharesDepleted: ZERO,
         sharesDepleted: ZERO,
-        tokensDepleted: new BigNumber("0.9", 10),
-        shareBalances: [ZERO, new BigNumber("2", 10)]
+        tokensDepleted: new BigNumber("1.2", 10),
+        shareBalances: [ZERO, new BigNumber("5", 10)]
       });
     }
   });

--- a/test/unit/trading/simulation/simulate-sell.js
+++ b/test/unit/trading/simulation/simulate-sell.js
@@ -44,7 +44,7 @@ describe("trading/simulation/simulate-sell", function () {
         gasFees: ZERO,
         otherSharesDepleted: ZERO,
         sharesDepleted: ZERO,
-        tokensDepleted: new BigNumber("1.5", 10),
+        tokensDepleted: new BigNumber("9", 10),
         shareBalances: [ZERO, new BigNumber("5", 10)]
       });
     }
@@ -79,7 +79,7 @@ describe("trading/simulation/simulate-sell", function () {
         gasFees: ZERO,
         otherSharesDepleted: ZERO,
         sharesDepleted: ZERO,
-        tokensDepleted: new BigNumber("1.3", 10),
+        tokensDepleted: new BigNumber("7", 10),
         shareBalances: [ZERO, new BigNumber("5", 10)]
       });
     }
@@ -121,8 +121,8 @@ describe("trading/simulation/simulate-sell", function () {
         gasFees: ZERO,
         otherSharesDepleted: ZERO,
         sharesDepleted: ZERO,
-        tokensDepleted: new BigNumber("1.5", 10),
-        shareBalances: [ZERO, new BigNumber("5", 10)]
+        tokensDepleted: new BigNumber("0.9", 10),
+        shareBalances: [ZERO, new BigNumber("2", 10)]
       });
     }
   });

--- a/test/unit/trading/simulation/simulate-trade.js
+++ b/test/unit/trading/simulation/simulate-trade.js
@@ -100,7 +100,7 @@ describe("trading/simulation/simulate-trade", function () {
         gasFees: "0",
         otherSharesDepleted: "0",
         sharesDepleted: "0",
-        tokensDepleted: "1.5",
+        tokensDepleted: "0.9",
         shareBalances: ["0", "5"]
       });
     }


### PR DESCRIPTION
We were originally using the full amount of shares for the ask order, instead of only the amount over which was available in the take simulation.

Do these new token depletion values look right?