### PR TITLE
simple warning when abi does not match parsed log

### DIFF
--- a/src/events/get-all-augur-logs.js
+++ b/src/events/get-all-augur-logs.js
@@ -42,6 +42,11 @@ function getAllAugurLogs(p, callback) {
         if (log && Array.isArray(log.topics) && log.topics.length) {
           var contractName = contractAddressToNameMap[log.address];
           var eventName = eventSignatureToNameMap[contractName][log.topics[0]];
+          if (eventName == null) {
+            console.log("Contract " + contractName + " has no event signature " +
+              log.topics[0] + " found on tx " + log.transactionHash);
+            return;
+          }
           try {
             var parsedLog = parseLogMessage(contractName, eventName, log, eventsAbi[contractName][eventName].inputs);
             allAugurLogs.push(parsedLog);


### PR DESCRIPTION
There's a lot that could go wrong in parseLog, so let's catch a really common error outside of that loop so we don't confuse where the issue is happening.

This gives an explanatory message when an event is found on a contract for which we do not have a signature mapping entry for. Looks like:

`
Contract Augur has no event signature 0x6eb56ff6339181597ed10da7672cd3c735551d93d152bd072fa389317f3a0149, found on tx 0xe4fefc44a289eaa733efade195b2e1fba68c18b5afea0cdf1a082f103e86f8f9
`