### PR TITLE
Removing params parameter from subscribeToEvent

### DIFF
--- a/src/augur-node/subscribe-to-event.js
+++ b/src/augur-node/subscribe-to-event.js
@@ -3,13 +3,11 @@
 var augurNodeState = require("./state");
 var submitJsonRpcRequest = require("./submit-json-rpc-request");
 
-function subscribeToEvent(eventName, params, subscriptionCallback, onComplete) {
-  params = Array.isArray(params) ? params : [];
-  params.unshift(eventName);
-  submitJsonRpcRequest("subscribe", params, function (err, response) {
+function subscribeToEvent(eventName, subscriptionCallback, onComplete) {
+  submitJsonRpcRequest("subscribe", [eventName], function (err, response) {
     if (err) return onComplete(err);
     augurNodeState.setEventCallback(response.subscription, subscriptionCallback);
-    onComplete(null);
+    onComplete(null, response.subscription);
   });
 }
 


### PR DESCRIPTION
`params` is not being used anywhere on the backend, so Paul and I figured it would be best to remove it for the time being.