### PR TITLE
add type for uploadBlockNumbers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -176,7 +176,10 @@ export class Augur {
   };
   public contracts: {
     abi: AbiMap;
-    addresses: ContractNameToAddressMap
+    addresses: ContractNameToAddressMap;
+    uploadBlockNumbers: {
+      [networkID: string]: number
+    };
   };
   public createMarket: {
     [functionName: string]: ApiFunction,


### PR DESCRIPTION
I'm defining this here because augur-contracts is going away. Technically, it should be a type in augur-contracts we re-export.