### PR TITLE
Making getMarketFromCreateMarketReceipt function publicly exposed

### DIFF
--- a/src/create-market/index.js
+++ b/src/create-market/index.js
@@ -6,4 +6,5 @@ module.exports = {
   createScalarMarket: require("./create-scalar-market"),
   getMarketCreationCost: require("./get-market-creation-cost"),
   getMarketCreationCostBreakdown: require("./get-market-creation-cost-breakdown"),
+  getMarketFromCreateMarketReceipt: require("./get-market-from-create-market-receipt"),
 };


### PR DESCRIPTION
Making `augur.createMarket.getMarketFromCreateMarketReceipt` public so that users calling on-contract functions like `Universe.createBinaryMarket` directly can get the address of the market once it's created.