### PR TITLE
remove special case handling for event being used in augur node

### DIFF
--- a/src/format/log/format-log-message.js
+++ b/src/format/log/format-log-message.js
@@ -30,31 +30,9 @@ function formatLogMessage(contractName, eventName, message) {
             });
           }
           return assign({}, immutableDelete(message, "outcomes"), formattedMessage);
-        case "WinningTokensRedeemed":
-          return assign({}, message, {
-            amountRedeemed: speedomatic.unfix(message.amountRedeemed, "string"),
-            reportingFeesReceived: speedomatic.unfix(message.reportingFeesReceived, "string"),
-          });
         case "ReportSubmitted":
           return assign({}, message, {
             amountStaked: speedomatic.unfix(message.amountStaked, "string"),
-          });
-        case "TokensTransferred":
-          return assign({}, message, {
-            value: speedomatic.unfix(message.value, "string"),
-          });
-        default:
-          return message;
-      }
-    case "LegacyReputationToken":
-      switch (eventName) {
-        case "Approval":
-          return assign({}, message, {
-            value: speedomatic.unfix(message.value, "string"),
-          });
-        case "Transfer":
-          return assign({}, message, {
-            value: speedomatic.unfix(message.value, "string"),
           });
         default:
           return message;

--- a/test/unit/format/log/format-log-message.js
+++ b/test/unit/format/log/format-log-message.js
@@ -26,7 +26,7 @@ describe("format/log/format-log-message", function () {
       assert.deepEqual(message, {
         owner: "0x1",
         spender: "0x2",
-        value: "10",
+        value: "0x8ac7230489e80000",
       });
     },
   });


### PR DESCRIPTION
Winning Tokens redeemed is no longer an event and the tokens transferred values being a different format than other token events is causing issues in augur node.