### PR TITLE
Add `numTicks` param to `placeTrade` function

### DIFF
--- a/src/trading/place-trade.js
+++ b/src/trading/place-trade.js
@@ -13,6 +13,7 @@ var normalizePrice = require("./normalize-price");
  * @param {string} p.estimatedCost Total cost (in ETH) of this trade, as a base-10 string.
  * @param {string} p.minPrice The minimum display (non-normalized) price for this market, as a base-10 string.
  * @param {string} p.maxPrice The maximum display (non-normalized) price for this market, as a base-10 string.
+ * @param {string} p.numTicks The number of ticks for this market.
  * @param {string} p.tickSize The tick size (interval) for this market.
  * @param {number} p._direction Order type (0 for "buy", 1 for "sell").
  * @param {string} p._market Market in which to trade, as a hex string.
@@ -38,6 +39,7 @@ function placeTrade(p) {
     tradeUntilAmountIsZero(assign({}, immutableDelete(p, ["limitPrice", "amount", "minPrice", "maxPrice"]), {
       _price: normalizedPrice,
       _fxpAmount: p.amount,
+      numTicks: p.numTicks,
       _betterOrderId: betterWorseOrders.betterOrderId,
       _worseOrderId: betterWorseOrders.worseOrderId,
     }));

--- a/src/trading/place-trade.js
+++ b/src/trading/place-trade.js
@@ -39,7 +39,6 @@ function placeTrade(p) {
     tradeUntilAmountIsZero(assign({}, immutableDelete(p, ["limitPrice", "amount", "minPrice", "maxPrice"]), {
       _price: normalizedPrice,
       _fxpAmount: p.amount,
-      numTicks: p.numTicks,
       _betterOrderId: betterWorseOrders.betterOrderId,
       _worseOrderId: betterWorseOrders.worseOrderId,
     }));


### PR DESCRIPTION
`augur.trading.placeTrade` was throwing the following exception when I tried calling it via the JS console:

```
Uncaught Error: new BigNumber() not a number: undefined
    at raise (bignumber.js?8748:1181)
    at eval (bignumber.js?8748:1169)
    at new BigNumber (bignumber.js?8748:195)
    at new BigNumber (bignumber.js?8748:205)
    at convertDecimalToFixedPoint (convert-decimal-to-fixed-point.js?8055:14)
    at calculateTradeCost (calculate-trade-cost.js?7a38:17)
    at tradeUntilAmountIsZero (trade-until-amount-is-zero.js?a628:33)
    at eval (place-trade.js?466a:39)
    at dispatchJsonRpcResponse (dispatch-json-rpc-response.js?4091:32)
    at WebSocket.webSocketClient.onmessage (ws-transport.js?9356:26)
```

This was happening because the function `tradeUntilAmountIsZero` was looking for `p.numTicks`, which was undefined.