### PR TITLE
Utilizing err parameter in callback for ethrpc.getTransactionReceipt

### DIFF
--- a/src/create-market/get-market-from-create-market-receipt.js
+++ b/src/create-market/get-market-from-create-market-receipt.js
@@ -6,7 +6,7 @@ var isObject = require("../utils/is-object");
 
 function getMarketFromCreateMarketReceipt(transactionHash, callback) {
   ethrpc.getTransactionReceipt(transactionHash, function (err, receipt) {
-    if (err) return callback(new Error("getTransactionReceipt failed:", err));
+    if (err) return callback(err);
     if (!isObject(receipt)) return callback(new Error("Transaction receipt not found for " + transactionHash));
     var marketCreatedLogs = findEventLogsInLogArray("Augur", "MarketCreated", receipt.logs);
     if (marketCreatedLogs == null || !marketCreatedLogs.length || marketCreatedLogs[0] == null || marketCreatedLogs[0].market == null) {

--- a/src/create-market/get-market-from-create-market-receipt.js
+++ b/src/create-market/get-market-from-create-market-receipt.js
@@ -6,7 +6,8 @@ var isObject = require("../utils/is-object");
 
 function getMarketFromCreateMarketReceipt(transactionHash, callback) {
   ethrpc.getTransactionReceipt(transactionHash, function (err, receipt) {
-    if (!isObject(receipt) || receipt.error) return callback(new Error("Transaction receipt not found for " + transactionHash));
+    if (err) return callback(new Error("getTransactionReceipt failed:", err));
+    if (!isObject(receipt)) return callback(new Error("Transaction receipt not found for " + transactionHash));
     var marketCreatedLogs = findEventLogsInLogArray("Augur", "MarketCreated", receipt.logs);
     if (marketCreatedLogs == null || !marketCreatedLogs.length || marketCreatedLogs[0] == null || marketCreatedLogs[0].market == null) {
       return callback(new Error("MarketCreated log not found for " + transactionHash));


### PR DESCRIPTION
I noticed the `err` parameter isn't getting used, so I added a check for it.