### PR TITLE
Update dispute-contribute.js

### DIFF
--- a/scripts/flash/dispute-contribute.js
+++ b/scripts/flash/dispute-contribute.js
@@ -114,7 +114,7 @@ function disputeContribute(augur, params, auth, callback) {
     var userAuth = null;
     if (process.env.REPORTER_PRIVATE_KEY) {
       userAuth = getPrivateKeyFromString(process.env.REPORTER_PRIVATE_KEY);
-    } else if (paramArray[2] !== undefined) {
+    } else if (paramArray[2].length > 0) {
       userAuth = getPrivateKeyFromString(paramArray[2]);
     }
     if (!userAuth) {

--- a/scripts/flash/dispute-contribute.js
+++ b/scripts/flash/dispute-contribute.js
@@ -114,7 +114,7 @@ function disputeContribute(augur, params, auth, callback) {
     var userAuth = null;
     if (process.env.REPORTER_PRIVATE_KEY) {
       userAuth = getPrivateKeyFromString(process.env.REPORTER_PRIVATE_KEY);
-    } else if (paramArray[2].length > 0) {
+    } else if (paramArray[2] && paramArray[2].length > 0) {
       userAuth = getPrivateKeyFromString(paramArray[2]);
     }
     if (!userAuth) {


### PR DESCRIPTION
fix so that private key doesn't need to be passed in when passing in amount.
>flash dispute-contribute <marketID>,outcome,,amount
just pass in empty for priv key