### PR TITLE
7825 trade group ids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7765,6 +7765,12 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "secure-random": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/secure-random/-/secure-random-1.1.1.tgz",
+      "integrity": "sha1-CIDy2MUYX0vLRoQFjINrTdsHFFo=",
+      "dev": true
+    },
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7768,8 +7768,7 @@
     "secure-random": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/secure-random/-/secure-random-1.1.1.tgz",
-      "integrity": "sha1-CIDy2MUYX0vLRoQFjINrTdsHFFo=",
-      "dev": true
+      "integrity": "sha1-CIDy2MUYX0vLRoQFjINrTdsHFFo="
     },
     "semver": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "lodash.isequal": "4.5.0",
     "options-parser": "^0.4.0",
     "parrotsay-api": "0.1.1",
+    "secure-random": "1.1.1",
     "speedomatic": "^2.1.3",
     "uuid": "3.0.0",
     "uuid-parse": "1.0.0"

--- a/scripts/dp/data/binary-order-book.json
+++ b/scripts/dp/data/binary-order-book.json
@@ -1,16 +1,16 @@
 {
   "buy": {
     "1": [
-      { "shares": "0.10", "price": "0.20" },
-      { "shares": "0.20", "price": "0.18" },
-      { "shares": "0.30", "price": "0.15" }
+      { "shares": "0.01", "price": "0.48" },
+      { "shares": "0.02", "price": "0.45" },
+      { "shares": "0.03", "price": "0.39" }
     ]
   },
   "sell": {
     "1": [
-      { "shares": "0.15", "price": "0.23" },
-      { "shares": "0.10", "price": "0.26" },
-      { "shares": "0.30", "price": "0.29" }
+      { "shares": "0.01", "price": "0.51" },
+      { "shares": "0.02", "price": "0.55" },
+      { "shares": "0.03", "price": "0.60" }
     ]
   }
 }

--- a/scripts/dp/lib/cancel-order.js
+++ b/scripts/dp/lib/cancel-order.js
@@ -13,12 +13,12 @@ function cancelOrder(augur, orderId, orderType, marketId, outcome, auth, callbac
       _orderId: orderId,
       onSent: function () {},
       onSuccess: function () {
-        if (debugOptions.cannedMarkets) console.log(chalk.green(marketId + " " + outcome + " ") + chalk.red.bold(orderType) + chalk.green(" " + orderId));
+        if (debugOptions.cannedMarkets) console.log(chalk.white.dim(new Date().toString()), chalk.green(marketId + " " + outcome + " ") + chalk.red.bold(orderType) + chalk.green(" " + orderId));
         callback(null);
       },
       onFailed: function (err) {
         // log the failure to the console and continue canceling orders
-        console.error(chalk.red(marketId + " " + outcome + " ") + chalk.red.bold(orderType) + chalk.green(" " + orderId), err);
+        console.error(chalk.white.dim(new Date().toString()), chalk.red(marketId + " " + outcome + " ") + chalk.red.bold(orderType) + chalk.green(" " + orderId), err);
         callback(null);
       },
     });

--- a/scripts/dp/lib/create-order-book.js
+++ b/scripts/dp/lib/create-order-book.js
@@ -7,11 +7,12 @@ var debugOptions = require("../../debug-options");
 
 function createOrderBook(augur, marketId, numOutcomes, maxPrice, minPrice, numTicks, orderBook, auth, callback) {
   async.forEachOf(orderBook, function (orders, orderType, nextOrderType) {
-    if (debugOptions.cannedMarkets) console.log(chalk.cyan.dim("orderType:"), chalk.cyan(orderType));
+    var tradeGroupId = augur.trading.generateTradeGroupId();
+    if (debugOptions.cannedMarkets) console.log(chalk.cyan.dim("Creating"), chalk.cyan(orderType), chalk.cyan.dim("orders - trade group ID"), chalk.green(tradeGroupId));
     async.forEachOf(orders, function (outcomeOrders, outcome, nextOutcome) {
-      if (debugOptions.cannedMarkets) console.log(chalk.cyan.dim("outcome:"), chalk.cyan(outcome));
+      if (debugOptions.cannedMarkets) console.log(chalk.cyan.dim("Creating orders for outcome"), chalk.cyan(outcome));
       async.each(outcomeOrders, function (order, nextOrder) {
-        createOrder(augur, marketId, parseInt(outcome, 10), numOutcomes, maxPrice, minPrice, numTicks, orderType, order, auth, nextOrder);
+        createOrder(augur, marketId, parseInt(outcome, 10), numOutcomes, maxPrice, minPrice, numTicks, orderType, order, tradeGroupId, auth, nextOrder);
       }, nextOutcome);
     }, nextOrderType);
   }, callback);

--- a/scripts/dp/lib/create-order.js
+++ b/scripts/dp/lib/create-order.js
@@ -33,7 +33,7 @@ function createOrder(augur, marketId, outcome, numOutcomes, maxPrice, minPrice, 
       outcome: outcome,
       price: order.price,
     }, function (err, betterWorseOrders) {
-      if (err) betterWorseOrders = { betterOrderId: 0, worseOrderId: 0 };
+      if (err) betterWorseOrders = { betterOrderId: "0x0", worseOrderId: "0x0" };
       augur.api.CreateOrder.publicCreateOrder({
         meta: auth,
         tx: { value: tradeCost.cost, gas: augur.constants.CREATE_ORDER_GAS },
@@ -42,9 +42,9 @@ function createOrder(augur, marketId, outcome, numOutcomes, maxPrice, minPrice, 
         _displayPrice: tradeCost.priceNumTicksRepresentation,
         _market: marketId,
         _outcome: outcome,
-        _betterOrderId: (betterWorseOrders || {}).betterOrderId || 0,
-        _worseOrderId: (betterWorseOrders || {}).worseOrderId || 0,
-        _tradeGroupId: 0,
+        _betterOrderId: (betterWorseOrders || {}).betterOrderId || "0x0",
+        _worseOrderId: (betterWorseOrders || {}).worseOrderId || "0x0",
+        _tradeGroupId: tradeGroupId,
         onSent: function (res) {
           if (debugOptions.cannedMarkets) {
             console.log(chalk.green.dim("publicCreateOrder sent:"), chalk.green(res.hash), chalk.cyan.dim(JSON.stringify(order)));
@@ -71,7 +71,7 @@ function createOrder(augur, marketId, outcome, numOutcomes, maxPrice, minPrice, 
       meta: auth,
       amount: order.shares,
       limitPrice: order.price,
-      estimatedCost: tradeCost.cost,
+      estimatedCost: speedomatic.unfix(tradeCost.cost, "string"),
       minPrice: minPrice,
       maxPrice: maxPrice,
       tickSize: tickSize,
@@ -79,7 +79,7 @@ function createOrder(augur, marketId, outcome, numOutcomes, maxPrice, minPrice, 
       _direction: orderTypeCode,
       _market: marketId,
       _outcome: outcome,
-      _tradeGroupId: 0,
+      _tradeGroupId: tradeGroupId,
       doNotCreateOrders: false,
       onSent: function (res) {
         if (debugOptions.cannedMarkets) console.log(chalk.green.dim("placeTrade sent:"), res);

--- a/scripts/dp/lib/create-order.js
+++ b/scripts/dp/lib/create-order.js
@@ -6,64 +6,99 @@ var speedomatic = require("speedomatic");
 var printTransactionStatus = require("./print-transaction-status");
 var debugOptions = require("../../debug-options");
 
-function convertDecimalToFixedPoint(decimalValue, conversionFactor) {
-  return new BigNumber(decimalValue, 10).times(new BigNumber(conversionFactor, 10)).floor().toFixed();
-}
+var USE_PUBLIC_CREATE_ORDER = false; // set to true to test CreateOrder.publicCreateOrder endpoint
 
-function createOrder(augur, marketId, outcome, numOutcomes, maxPrice, minPrice, numTicks, orderType, order, auth, callback) {
+function createOrder(augur, marketId, outcome, numOutcomes, maxPrice, minPrice, numTicks, orderType, order, tradeGroupId, auth, callback) {
   var normalizedPrice = augur.trading.normalizePrice({ price: order.price, maxPrice: maxPrice, minPrice: minPrice });
-  if (debugOptions.cannedMarkets) {
-    console.log("price:", order.price);
-    console.log("normalizedPrice:", normalizedPrice);
-  }
   var tickSize = (new BigNumber(maxPrice, 10).minus(new BigNumber(minPrice, 10))).dividedBy(new BigNumber(numTicks, 10)).toFixed();
-  var bnOnChainShares = new BigNumber(convertDecimalToFixedPoint(order.shares, speedomatic.fix(tickSize, "string")), 10);
-  var bnPrice = new BigNumber(convertDecimalToFixedPoint(normalizedPrice, numTicks), 10);
-  var orderTypeCode, bnCost;
-  if (orderType === "buy") {
-    orderTypeCode = 0;
-    bnCost = bnOnChainShares.times(bnPrice);
-  } else {
-    orderTypeCode = 1;
-    if (debugOptions.cannedMarkets) {
-      console.log("on chain shares:", bnOnChainShares.toFixed());
-      console.log("numTicks:", numTicks);
-      console.log("price:", bnPrice.toFixed());
-    }
-    bnCost = bnOnChainShares.times(new BigNumber(numTicks, 10).minus(bnPrice));
-  }
-  if (debugOptions.cannedMarkets) console.log(chalk.cyan.dim("cost:"), chalk.cyan(speedomatic.unfix(bnCost, "string")));
-  augur.api.CreateOrder.publicCreateOrder({
-    meta: auth,
-    tx: { value: "0x" + bnCost.toString(16), gas: augur.constants.CREATE_ORDER_GAS },
-    _type: orderTypeCode,
-    _attoshares: "0x" + bnOnChainShares.toString(16),
-    _displayPrice: "0x" + bnPrice.toString(16),
-    _market: marketId,
-    _outcome: outcome,
-    _betterOrderId: 0,
-    _worseOrderId: 0,
-    _tradeGroupId: 0,
-    onSent: function (res) {
-      if (debugOptions.cannedMarkets) {
-        console.log(chalk.green.dim("publicCreateOrder sent:"), chalk.green(res.hash), chalk.cyan.dim(JSON.stringify(order)));
-      }
-    },
-    onSuccess: function (res) {
-      if (debugOptions.cannedMarkets) {
-        console.log(chalk.green.dim("publicCreateOrder success:"), chalk.green(res.callReturn), chalk.cyan.dim(JSON.stringify(order)));
-        printTransactionStatus(augur.rpc, res.hash);
-      }
-      callback(null, res);
-    },
-    onFailed: function (err) {
-      if (debugOptions.cannedMarkets) {
-        console.error(chalk.red.bold("publicCreateOrder failed:"), err, chalk.red.dim(JSON.stringify(order)));
-        if (err != null) printTransactionStatus(augur.rpc, err.hash);
-      }
-      callback(err);
-    },
+  var orderTypeCode = orderType === "buy" ? 0 : 1;
+  var tradeCost = augur.trading.calculateTradeCost({
+    price: order.price,
+    amount: order.shares,
+    numTicks: numTicks,
+    tickSize: tickSize,
+    orderType: orderTypeCode,
   });
+  if (debugOptions.cannedMarkets) {
+    console.log("price | normalized price:", order.price, "|", normalizedPrice);
+    console.log("numTicks:", numTicks);
+    console.log("num shares to trade (numTicks representation):", new BigNumber(tradeCost.amountNumTicksRepresentation, 16).toFixed());
+    console.log("limit price (numTicks representation):", new BigNumber(tradeCost.priceNumTicksRepresentation, 16).toFixed());
+    console.log(chalk.green.bold("cost:"), chalk.cyan(speedomatic.unfix(new BigNumber(tradeCost.cost, 16), "string")), chalk.cyan.dim("ETH"));
+  }
+  if (USE_PUBLIC_CREATE_ORDER) {
+    augur.trading.getBetterWorseOrders({
+      orderType: orderType,
+      marketId: marketId,
+      outcome: outcome,
+      price: order.price,
+    }, function (err, betterWorseOrders) {
+      if (err) {
+        console.error("*************getBetterWorseOrders failed:", err, betterWorseOrders);
+        return callback(err);
+      }
+      augur.api.CreateOrder.publicCreateOrder({
+        meta: auth,
+        tx: { value: tradeCost.cost, gas: augur.constants.CREATE_ORDER_GAS },
+        _type: orderTypeCode,
+        _attoshares: tradeCost.amountNumTicksRepresentation,
+        _displayPrice: tradeCost.priceNumTicksRepresentation,
+        _market: marketId,
+        _outcome: outcome,
+        _betterOrderId: (betterWorseOrders || {}).betterOrderId || 0,
+        _worseOrderId: (betterWorseOrders || {}).worseOrderId || 0,
+        _tradeGroupId: 0,
+        onSent: function (res) {
+          if (debugOptions.cannedMarkets) {
+            console.log(chalk.green.dim("publicCreateOrder sent:"), chalk.green(res.hash), chalk.cyan.dim(JSON.stringify(order)));
+          }
+        },
+        onSuccess: function (res) {
+          if (debugOptions.cannedMarkets) {
+            console.log(chalk.green.dim("publicCreateOrder success:"), chalk.green(res.callReturn), chalk.cyan.dim(JSON.stringify(order)));
+            printTransactionStatus(augur.rpc, res.hash);
+          }
+          callback(null, res);
+        },
+        onFailed: function (err) {
+          if (debugOptions.cannedMarkets) {
+            console.error(chalk.red.bold("publicCreateOrder failed:"), err, chalk.red.dim(JSON.stringify(order)));
+            if (err != null) printTransactionStatus(augur.rpc, err.hash);
+          }
+          callback(err);
+        },
+      });
+    });
+  } else {
+    var placeTradeParams = {
+      meta: auth,
+      amount: order.shares,
+      limitPrice: order.price,
+      estimatedCost: tradeCost.cost,
+      minPrice: minPrice,
+      maxPrice: maxPrice,
+      tickSize: tickSize,
+      numTicks: numTicks,
+      _direction: orderTypeCode,
+      _market: marketId,
+      _outcome: outcome,
+      _tradeGroupId: 0,
+      doNotCreateOrders: false,
+      onSent: function (res) {
+        if (debugOptions.cannedMarkets) console.log(chalk.green.dim("placeTrade sent:"), res);
+      },
+      onSuccess: function (tradeOnChainAmountRemaining) {
+        if (debugOptions.cannedMarkets) console.log(chalk.green.dim("placeTrade success:"), tradeOnChainAmountRemaining);
+        callback(null);
+      },
+      onFailed: function (err) {
+        if (debugOptions.cannedMarkets) console.error(chalk.red.bold("placeTrade failed:"), err);
+        callback(err);
+      },
+    };
+    if (debugOptions.cannedMarkets) console.log("create-order placeTradeParams:", placeTradeParams);
+    augur.trading.placeTrade(placeTradeParams);
+  }
 }
 
 module.exports = createOrder;

--- a/scripts/dp/lib/create-order.js
+++ b/scripts/dp/lib/create-order.js
@@ -6,7 +6,7 @@ var speedomatic = require("speedomatic");
 var printTransactionStatus = require("./print-transaction-status");
 var debugOptions = require("../../debug-options");
 
-var USE_PUBLIC_CREATE_ORDER = false; // set to true to test CreateOrder.publicCreateOrder endpoint
+var USE_PUBLIC_CREATE_ORDER = true; // set to false to test trading.placeTrade endpoint
 
 function createOrder(augur, marketId, outcome, numOutcomes, maxPrice, minPrice, numTicks, orderType, order, tradeGroupId, auth, callback) {
   var normalizedPrice = augur.trading.normalizePrice({ price: order.price, maxPrice: maxPrice, minPrice: minPrice });
@@ -33,10 +33,7 @@ function createOrder(augur, marketId, outcome, numOutcomes, maxPrice, minPrice, 
       outcome: outcome,
       price: order.price,
     }, function (err, betterWorseOrders) {
-      if (err) {
-        console.error("*************getBetterWorseOrders failed:", err, betterWorseOrders);
-        return callback(err);
-      }
+      if (err) betterWorseOrders = { betterOrderId: 0, worseOrderId: 0 };
       augur.api.CreateOrder.publicCreateOrder({
         meta: auth,
         tx: { value: tradeCost.cost, gas: augur.constants.CREATE_ORDER_GAS },

--- a/src/augur-node/submit-json-rpc-request.js
+++ b/src/augur-node/submit-json-rpc-request.js
@@ -3,10 +3,14 @@
 var augurNodeState = require("./state");
 
 function submitJsonRpcRequest(method, params, callback) {
+  var transport = augurNodeState.getTransport();
+  if (transport == null) {
+    return callback(new Error("Not connected to augur-node, could not submit request " + method + " " + JSON.stringify(params)));
+  }
   var id = augurNodeState.getNumRequests();
   augurNodeState.incrementNumRequests();
   augurNodeState.setCallback(id, callback);
-  augurNodeState.getTransport().submitWork({ id: id, jsonrpc: "2.0", method: method, params: params });
+  transport.submitWork({ id: id, jsonrpc: "2.0", method: method, params: params });
 }
 
 module.exports = submitJsonRpcRequest;

--- a/src/constants.js
+++ b/src/constants.js
@@ -84,7 +84,7 @@ module.exports = {
   GET_LOGS_DEFAULT_TO_BLOCK: "latest",
 
   // maximum number of transactions to auto-submit in parallel
-  PARALLEL_LIMIT: 5,
+  PARALLEL_LIMIT: 10,
 
   TRADE_GROUP_ID_NUM_BYTES: 32,
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -85,4 +85,6 @@ module.exports = {
 
   // maximum number of transactions to auto-submit in parallel
   PARALLEL_LIMIT: 5,
+
+  TRADE_GROUP_ID_NUM_BYTES: 32,
 };

--- a/src/markets/get-unclaimed-market-creator-fees.js
+++ b/src/markets/get-unclaimed-market-creator-fees.js
@@ -12,7 +12,7 @@ var augurNode = require("../augur-node");
  * Returns information about unclaimed market creator fees. Fees are only available on finalized markets.
  * @param {Object} p Parameters object.
  * @param {string[]} p.marketIds Contract addresses of the markets for which to get details, as hexadecimal strings.
- * @returns {MarketCreatorFee[]}
+ * @return {MarketCreatorFee[]}
  */
 function getUnclaimedMarketCreatorFees(p, callback) {
   augurNode.submitRequest("getUnclaimedMarketCreatorFees", p, callback);

--- a/src/trading/calculate-trade-cost.js
+++ b/src/trading/calculate-trade-cost.js
@@ -25,7 +25,7 @@ function calculateTradeCost(p) {
   var adjustedPrice = p.orderType === 0 ? new BigNumber(priceNumTicksRepresentation, 16) : new BigNumber(p.numTicks, 10).minus(new BigNumber(priceNumTicksRepresentation, 16));
   var amountNumTicksRepresentation = convertDecimalToFixedPoint(p.amount, speedomatic.fix(p.tickSize, "string"));
   return {
-    cost: "0x" + new BigNumber(amountNumTicksRepresentation, 16).times(adjustedPrice).toString(16),
+    cost: speedomatic.prefixHex(new BigNumber(amountNumTicksRepresentation, 16).times(adjustedPrice).toString(16)),
     amountNumTicksRepresentation: amountNumTicksRepresentation,
     priceNumTicksRepresentation: priceNumTicksRepresentation,
   };

--- a/src/trading/calculate-trade-cost.js
+++ b/src/trading/calculate-trade-cost.js
@@ -4,21 +4,29 @@ var BigNumber = require("bignumber.js");
 var speedomatic = require("speedomatic");
 var convertDecimalToFixedPoint = require("../utils/convert-decimal-to-fixed-point");
 
+/** Type definition for TradeCost.
+ * @typedef {Object} TradeCost
+ * @property {string} cost Wei (attoether) value needed for this trade, as a hexadecimal string.
+ * @property {string} amountNumTicksRepresentation Number of shares to trade in on-chain (numTicks) representation, as a hexadecimal string.
+ * @property {string} priceNumTicksRepresentation Limit price in on-chain (numTicks) representation, as a hexadecimal string.
+ */
+
 /**
  * @param {Object} p Parameters object.
  * @param {string} p.price Normalized limit price for this trade, as a base-10 string.
  * @param {string} p.amount Number of shares to trade, as a base-10 string.
- * @param {string} p.numTicks The number of ticks for this market.
- * @param {string} p.tickSize The tick size (interval) for this market.
+ * @param {string} p.numTicks The number of ticks for this market, as a base-10 string.
+ * @param {string} p.tickSize The tick size (interval) for this market, as a base-10 string.
  * @param {number} p.orderType Order type (0 for "buy", 1 for "sell").
+ * @return {TradeCost} Cost breakdown of this trade.
  */
 function calculateTradeCost(p) {
   var priceNumTicksRepresentation = convertDecimalToFixedPoint(p.price, p.numTicks);
   var adjustedPrice = p.orderType === 0 ? new BigNumber(priceNumTicksRepresentation, 16) : new BigNumber(p.numTicks, 10).minus(new BigNumber(priceNumTicksRepresentation, 16));
-  var onChainAmount = convertDecimalToFixedPoint(p.amount, speedomatic.fix(p.tickSize, "string"));
+  var amountNumTicksRepresentation = convertDecimalToFixedPoint(p.amount, speedomatic.fix(p.tickSize, "string"));
   return {
-    cost: speedomatic.unfix(new BigNumber(onChainAmount, 16).times(adjustedPrice)).toFixed(),
-    onChainAmount: onChainAmount,
+    cost: "0x" + new BigNumber(amountNumTicksRepresentation, 16).times(adjustedPrice).toString(16),
+    amountNumTicksRepresentation: amountNumTicksRepresentation,
     priceNumTicksRepresentation: priceNumTicksRepresentation,
   };
 }

--- a/src/trading/generate-trade-group-id.js
+++ b/src/trading/generate-trade-group-id.js
@@ -1,0 +1,10 @@
+"use strict";
+
+var secureRandom = require("secure-random");
+var TRADE_GROUP_ID_NUM_BYTES = require("../constants").TRADE_GROUP_ID_NUM_BYTES;
+
+function generateTradeGroupId(tradeGroupIdNumBytes) {
+  return "0x" + Buffer.from(secureRandom(tradeGroupIdNumBytes || TRADE_GROUP_ID_NUM_BYTES)).toString("hex");
+}
+
+module.exports = generateTradeGroupId;

--- a/src/trading/get-user-trading-history.js
+++ b/src/trading/get-user-trading-history.js
@@ -17,7 +17,7 @@
  * @property {number} outcome Outcome being bought/sold.
  * @property {string} shareToken Contract address of the share token that was bought or sold, as a hexadecimal string.
  * @property {number} timestamp Description pending.
- * @property {number|null} tradeGroupId Description pending.
+ * @property {number|null} tradeGroupId ID logged with each trade transaction (can be used to group trades client-side), as a hex string.
  */
 
 var augurNode = require("../augur-node");

--- a/src/trading/index.js
+++ b/src/trading/index.js
@@ -15,4 +15,6 @@ module.exports = {
   placeTrade: require("./place-trade"),
   tradeUntilAmountIsZero: require("./trade-until-amount-is-zero"),
   getOrders: require("./get-orders"),
+  calculateTradeCost: require("./calculate-trade-cost"),
+  generateTradeGroupId: require("./generate-trade-group-id"),
 };

--- a/src/trading/place-trade.js
+++ b/src/trading/place-trade.js
@@ -39,8 +39,8 @@ function placeTrade(p) {
     tradeUntilAmountIsZero(assign({}, immutableDelete(p, ["limitPrice", "amount", "minPrice", "maxPrice"]), {
       _price: normalizedPrice,
       _fxpAmount: p.amount,
-      _betterOrderId: betterWorseOrders.betterOrderId,
-      _worseOrderId: betterWorseOrders.worseOrderId,
+      _betterOrderId: (betterWorseOrders || {}).betterOrderId || "0x0",
+      _worseOrderId: (betterWorseOrders || {}).worseOrderId || "0x0",
     }));
   });
 }

--- a/src/trading/trade-until-amount-is-zero.js
+++ b/src/trading/trade-until-amount-is-zero.js
@@ -31,27 +31,30 @@ var constants = require("../constants");
 function tradeUntilAmountIsZero(p) {
   console.log("tradeUntilAmountIsZero:", JSON.stringify(immutableDelete(p, "meta"), null, 2));
   var tradeCost = calculateTradeCost({ price: p._price, amount: p._fxpAmount, numTicks: p.numTicks, tickSize: p.tickSize, orderType: p._direction });
-  var maxCost = new BigNumber(tradeCost.cost, 10);
-  var onChainAmount = tradeCost.onChainAmount;
+  var maxCost = new BigNumber(tradeCost.cost, 16);
+  var amountNumTicksRepresentation = tradeCost.amountNumTicksRepresentation;
   var priceNumTicksRepresentation = tradeCost.priceNumTicksRepresentation;
-  var cost = p.estimatedCost != null ? new BigNumber(p.estimatedCost, 10) : maxCost;
-  if (maxCost.lt(constants.PRECISION.zero)) return p.onSuccess(null);
-  console.log("cost:", cost.toFixed(), "ETH");
+  var cost = p.estimatedCost != null ? speedomatic.fix(p.estimatedCost) : maxCost;
+  console.log("cost:", speedomatic.unfix(cost, "string"), "ETH");
+  if (maxCost.lt(constants.PRECISION.zero)) {
+    console.log("tradeUntilAmountIsZero complete: only dust remaining");
+    return p.onSuccess(null);
+  }
   var tradePayload = assign({}, immutableDelete(p, ["doNotCreateOrders", "numTicks", "tickSize", "estimatedCost"]), {
-    tx: assign({ value: speedomatic.fix(cost, "hex"), gas: constants.TRADE_GAS }, p.tx),
-    _fxpAmount: onChainAmount,
+    tx: assign({ value: "0x" + cost.toString(16), gas: constants.TRADE_GAS }, p.tx),
+    _fxpAmount: amountNumTicksRepresentation,
     _price: priceNumTicksRepresentation,
     onSuccess: function (res) {
-      console.log("res:", res);
+      console.log("trade successful:", res);
       getTradeAmountRemaining({
         transactionHash: res.hash,
-        startingOnChainAmount: onChainAmount,
+        startingOnChainAmount: amountNumTicksRepresentation,
         priceNumTicksRepresentation: priceNumTicksRepresentation,
       }, function (err, tradeOnChainAmountRemaining) {
         if (err) return p.onFailed(err);
         console.log("starting amount: ", p._fxpAmount);
         console.log("amount remaining:", convertFixedPointToDecimal(tradeOnChainAmountRemaining, speedomatic.fix(p.tickSize, "string")));
-        if (new BigNumber(tradeOnChainAmountRemaining, 10).eq(new BigNumber(onChainAmount, 16))) {
+        if (new BigNumber(tradeOnChainAmountRemaining, 10).eq(new BigNumber(amountNumTicksRepresentation, 16))) {
           if (p.doNotCreateOrders) return p.onSuccess(tradeOnChainAmountRemaining);
           return p.onFailed("Trade completed but amount of trade unchanged");
         }

--- a/src/trading/trade-until-amount-is-zero.js
+++ b/src/trading/trade-until-amount-is-zero.js
@@ -34,7 +34,7 @@ function tradeUntilAmountIsZero(p) {
   var maxCost = new BigNumber(tradeCost.cost, 16);
   var amountNumTicksRepresentation = tradeCost.amountNumTicksRepresentation;
   var priceNumTicksRepresentation = tradeCost.priceNumTicksRepresentation;
-  var cost = p.estimatedCost != null ? speedomatic.fix(p.estimatedCost) : maxCost;
+  var cost = p.estimatedCost != null && new BigNumber(p.estimatedCost, 10).gt(constants.ZERO) ? speedomatic.fix(p.estimatedCost) : maxCost;
   console.log("cost:", speedomatic.unfix(cost, "string"), "ETH");
   if (maxCost.lt(constants.PRECISION.zero)) {
     console.log("tradeUntilAmountIsZero complete: only dust remaining");

--- a/src/trading/trade-until-amount-is-zero.js
+++ b/src/trading/trade-until-amount-is-zero.js
@@ -41,7 +41,7 @@ function tradeUntilAmountIsZero(p) {
     return p.onSuccess(null);
   }
   var tradePayload = assign({}, immutableDelete(p, ["doNotCreateOrders", "numTicks", "tickSize", "estimatedCost"]), {
-    tx: assign({ value: "0x" + cost.toString(16), gas: constants.TRADE_GAS }, p.tx),
+    tx: assign({ value: speedomatic.prefixHex(cost.toString(16)), gas: constants.TRADE_GAS }, p.tx),
     _fxpAmount: amountNumTicksRepresentation,
     _price: priceNumTicksRepresentation,
     onSuccess: function (res) {

--- a/src/trading/trade-until-amount-is-zero.js
+++ b/src/trading/trade-until-amount-is-zero.js
@@ -58,7 +58,7 @@ function tradeUntilAmountIsZero(p) {
           if (p.doNotCreateOrders) return p.onSuccess(tradeOnChainAmountRemaining);
           return p.onFailed("Trade completed but amount of trade unchanged");
         }
-        var updatedEstimatedCost = p.estimatedCost == null ? null : cost.minus(speedomatic.unfix(res.value)).toFixed();
+        var updatedEstimatedCost = p.estimatedCost == null ? null : speedomatic.unfix(cost.minus(new BigNumber(res.value, 16)), "string");
         console.log("updated estimated cost:", updatedEstimatedCost);
         tradeUntilAmountIsZero(assign({}, p, {
           estimatedCost: updatedEstimatedCost,

--- a/test/unit/trading/place-trade.js
+++ b/test/unit/trading/place-trade.js
@@ -63,8 +63,8 @@ describe("trading/place-trade", function () {
         assert.strictEqual(p._fxpAmount, "10");
         assert.strictEqual(p._price, "0.5");
         assert.strictEqual(p._tradeGroupId, "0x1");
-        assert.isNull(p._betterOrderId);
-        assert.isNull(p._worseOrderId);
+        assert.strictEqual(p._betterOrderId, "0x0");
+        assert.strictEqual(p._worseOrderId, "0x0");
         assert.isFunction(p.onSent);
         assert.isFunction(p.onSuccess);
         assert.isFunction(p.onFailed);


### PR DESCRIPTION
Resolves:
https://app.clubhouse.io/augur/story/7822/add-calculatetradecost-to-public-trading-api
https://app.clubhouse.io/augur/story/7823/reduce-number-of-shares-used-in-canned-market-orders
https://app.clubhouse.io/augur/story/7824/option-to-use-placetrade-publictrade-for-create-orders-script-instead-of-publiccreateorder
https://app.clubhouse.io/augur/story/7825/assign-trade-group-ids-to-dp-scripted-trades
https://app.clubhouse.io/augur/story/7833/improve-not-connected-to-augur-node-error

Sorry for lumping them into one big PR!  They're individually such small issues that I felt this was preferable to opening 5 tiny PRs...
