### PR TITLE
pulled out calling rep faucet

### DIFF
--- a/scripts/flash/dispute-contribute.js
+++ b/scripts/flash/dispute-contribute.js
@@ -5,7 +5,7 @@
 var chalk = require("chalk");
 var getTime = require("./get-timestamp");
 var getPrivateKeyFromString = require("../dp/lib/get-private-key").getPrivateKeyFromString;
-var repFaucet = require("../rep-faucet");
+var getRepTokens = require("./get-rep-tokens");
 var speedomatic = require("speedomatic");
 var displayTime = require("./display-time");
 var setTimestamp = require("./set-timestamp");
@@ -16,7 +16,7 @@ var doMarketContribute = require("./do-market-contribute");
 var day = 108000; // day
 
 function disputeContributeInternal(augur, marketId, outcome, amount, disputerAuth, invalid, auth, callback) {
-  repFaucet(augur, disputerAuth, function (err) {
+  getRepTokens(augur, amount, disputerAuth, function (err) {
     if (err) {
       console.log(chalk.red("Error"), chalk.red(err));
       return callback(err);

--- a/scripts/flash/get-rep-tokens.js
+++ b/scripts/flash/get-rep-tokens.js
@@ -1,0 +1,27 @@
+var repFaucet = require("../rep-faucet");
+var getBalance = require("../dp/lib/get-balances");
+var chalk = require("chalk");
+
+function getRepTokens(augur, amount, auth, callback) {
+  var universe = augur.contracts.addresses[augur.rpc.getNetworkID()].Universe;
+  getBalance(augur, universe, auth.address, function (err, balances) {
+    if (err) {
+      console.log(chalk.red(err));
+      return callback(JSON.stringify(err));
+    }
+    if (balances.reputation < parseInt(amount, 10)) {
+      repFaucet(augur, amount, auth, function (err) {
+        if (err) {
+          console.log(chalk.red("Error"), chalk.red(err));
+          return callback(err);
+        }
+        callback(null);
+      });
+    } else {
+      callback(null);
+    }
+  });
+}
+
+
+module.exports = getRepTokens;


### PR DESCRIPTION
since the creation of fork scripts and changes to rep-faucet. It was missed that dispute-contribute needs to pass in amount of rep. 
Changed to pull out calling rep-faucet so that we call rep-faucet only if we need rep.