### PR TITLE
merge addresses and blocks json files based on networkid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,11 @@ WORKDIR /augur.js
 COPY src src
 COPY scripts scripts
 COPY data data
+RUN rm -rf /augur.js/src/contracts/addresses.json \
+  && rm -rf /augur.js/src/contracts/upload-block-numbers.json \
+  && echo {} > /augur.js/src/contracts/addresses.json \
+  && echo {} > /augur.js/src/contracts/upload-block-numbers.json
+
 
 RUN bash scripts/run-geth-and-deploy.sh && rm -rf node_modules
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,7 @@ WORKDIR /augur.js
 COPY src src
 COPY scripts scripts
 COPY data data
-RUN rm -rf /augur.js/src/contracts/addresses.json \
-  && rm -rf /augur.js/src/contracts/upload-block-numbers.json \
-  && echo {} > /augur.js/src/contracts/addresses.json \
+RUN echo {} > /augur.js/src/contracts/addresses.json \
   && echo {} > /augur.js/src/contracts/upload-block-numbers.json
 
 

--- a/scripts/copy-docker-files.sh
+++ b/scripts/copy-docker-files.sh
@@ -1,28 +1,29 @@
 # copy files so augur.js is consistant with docker image
 IMAGE="augurproject/dev-pop-geth:latest"
 TEMP1="./temp.file"
-TEMP2="./temp2.file"
+ADD_TEMP2="./temp2.file"
+BLOCK_TEMP2=".temp3.file"
 ADDRESSES="./src/contracts/addresses.json"
 BLOCKS="./src/contracts/upload-block-numbers.json"
 
 docker run --rm --entrypoint cat $IMAGE /augur.js/src/contracts/addresses.json > $TEMP1
-node ./scripts/merge-json-files -p $ADDRESSES -s $TEMP1 -o $TEMP2
+node ./scripts/merge-json-files -p $ADDRESSES -s $TEMP1 -o $ADD_TEMP2
+ADD_RESULT_CODE=$?
 
-if [ $? -eq 1 ]; then
+docker run --rm --entrypoint cat $IMAGE /augur.js/src/contracts/upload-block-numbers.json > $TEMP1
+node ./scripts/merge-json-files -p $BLOCKS -s $TEMP1 -o $BLOCK_TEMP2
+ADD_BLOCK_CODE=$?
+
+if [ $ADD_RESULT_CODE -eq 1 ]; then
  echo 'ERROR occurred in updating Addresses.json file'
  exit
 fi
 
-cat $TEMP2 > $ADDRESSES
-rm -rf $TEMP1 $TEMP2
-
-docker run --rm --entrypoint cat $IMAGE /augur.js/src/contracts/upload-block-numbers.json > $TEMP1
-node ./scripts/merge-json-files -p $BLOCKS -s $TEMP1 -o $TEMP2
-
-if [ $? -eq 1 ]; then
+if [ $ADD_BLOCK_CODE -eq 1 ]; then
  echo 'ERROR occurred in updating upload-block-numbers.json file'
  exit
 fi
 
-cat $TEMP2 > $BLOCKS
-rm -rf $TEMP1 $TEMP2
+cat $ADD_TEMP2 > $ADDRESSES
+cat $BLOCK_TEMP2 > $BLOCKS
+rm -rf $TEMP1 $ADD_TEMP2 $BLOCK_TEMP2

--- a/scripts/copy-docker-files.sh
+++ b/scripts/copy-docker-files.sh
@@ -1,3 +1,16 @@
 # copy files so augur.js is consistant with docker image
-docker run --rm --entrypoint cat augurproject/dev-pop-geth:latest /augur.js/src/contracts/addresses.json > ./src/contracts/addresses.json
-docker run --rm --entrypoint cat augurproject/dev-pop-geth:latest /augur.js/src/contracts/upload-block-numbers.json > ./src/contracts/upload-block-numbers.json
+IMAGE="augurproject/dev-pop-geth:latest"
+TEMP1="./temp.file"
+TEMP2="./temp2.file"
+ADDRESSES="./src/contracts/addresses.json"
+BLOCKS="./src/contracts/upload-block-numbers.json"
+
+docker run --rm --entrypoint cat $IMAGE /augur.js/src/contracts/addresses.json > $TEMP1
+node ./scripts/merge-json-files -p $ADDRESSES -s $TEMP1 > $TEMP2
+cat $TEMP2 > $ADDRESSES
+rm -rf $TEMP1 $TEMP2
+
+docker run --rm --entrypoint cat $IMAGE /augur.js/src/contracts/upload-block-numbers.json > $TEMP1
+node ./scripts/merge-json-files -p $BLOCKS -s $TEMP1 > $TEMP2
+cat $TEMP2 > $BLOCKS
+rm -rf $TEMP1 $TEMP2

--- a/scripts/copy-docker-files.sh
+++ b/scripts/copy-docker-files.sh
@@ -6,11 +6,23 @@ ADDRESSES="./src/contracts/addresses.json"
 BLOCKS="./src/contracts/upload-block-numbers.json"
 
 docker run --rm --entrypoint cat $IMAGE /augur.js/src/contracts/addresses.json > $TEMP1
-node ./scripts/merge-json-files -p $ADDRESSES -s $TEMP1 > $TEMP2
+node ./scripts/merge-json-files -p $ADDRESSES -s $TEMP1 -o $TEMP2
+
+if [ $? -eq 1 ]; then
+ echo 'ERROR occurred in updating Addresses.json file'
+ exit
+fi
+
 cat $TEMP2 > $ADDRESSES
 rm -rf $TEMP1 $TEMP2
 
 docker run --rm --entrypoint cat $IMAGE /augur.js/src/contracts/upload-block-numbers.json > $TEMP1
-node ./scripts/merge-json-files -p $BLOCKS -s $TEMP1 > $TEMP2
+node ./scripts/merge-json-files -p $BLOCKS -s $TEMP1 -o $TEMP2
+
+if [ $? -eq 1 ]; then
+ echo 'ERROR occurred in updating upload-block-numbers.json file'
+ exit
+fi
+
 cat $TEMP2 > $BLOCKS
 rm -rf $TEMP1 $TEMP2

--- a/scripts/merge-json-files.js
+++ b/scripts/merge-json-files.js
@@ -18,20 +18,25 @@ var fileType = "utf8";
 var opts = {
   primary: { required: true, short: "p", help: "Existing Nework addresses.json file"},
   secondary: { required: true, short: "s", help: "Addresses.json file to merge into main addresses.json file"},
+  output: { required: true, short: "o", help: "output file of the merge"},
 };
 var args = options.parse(opts, process.argv, function (error) {
   errorOccurred(error, opts);
 });
 var primaryFile = args.opt.primary;
 var secondaryFile = args.opt.secondary;
+var output = args.opt.output;
 fs.readFile(primaryFile, fileType, function (err, primaryContent) {
   errorOccurred(err, opts);
   if (!primaryContent || primaryContent.length === 0) return console.error("existing addresses.json file has no content");
   fs.readFile(secondaryFile, fileType, function (err, secondaryContent) {
     errorOccurred(err, opts);
     if (!secondaryContent || secondaryContent.length === 0) return console.error("new addresses.json file has no content");
-    console.log(mergeJsonFiles(primaryContent, secondaryContent));
-    process.exit(0);
+    var result = mergeJsonFiles(primaryContent, secondaryContent);
+    fs.writeFile(output, result, function (err) {
+      errorOccurred(err, opts);
+      process.exit(0);
+    });
   });
 });
 

--- a/scripts/merge-json-files.js
+++ b/scripts/merge-json-files.js
@@ -10,7 +10,7 @@ function errorOccurred(err, opts) {
   if (err) {
     options.help(opts);
     console.error("ERROR:", err);
-    process.exit();
+    process.exit(1);
   }
 }
 var fileType = "utf8";
@@ -31,6 +31,7 @@ fs.readFile(primaryFile, fileType, function (err, primaryContent) {
     errorOccurred(err, opts);
     if (!secondaryContent || secondaryContent.length === 0) return console.error("new addresses.json file has no content");
     console.log(mergeJsonFiles(primaryContent, secondaryContent));
+    process.exit(0);
   });
 });
 

--- a/scripts/merge-json-files.js
+++ b/scripts/merge-json-files.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+var options = require("options-parser");
+var fs = require("fs");
+
+function mergeJsonFiles(existingAddresses, newNetworkIdAddresses) {
+  return JSON.stringify(Object.assign(JSON.parse(existingAddresses), JSON.parse(newNetworkIdAddresses)), null, " ");
+}
+
+function errorOccurred(err, opts) {
+  if (err) {
+    options.help(opts);
+    console.error("ERROR:", err);
+    process.exit();
+  }
+}
+var fileType = "utf8";
+
+var opts = {
+  primary: { required: true, short: "p", help: "Existing Nework addresses.json file"},
+  secondary: { required: true, short: "s", help: "Addresses.json file to merge into main addresses.json file"},
+};
+var args = options.parse(opts, process.argv, function (error) {
+  errorOccurred(error, opts);
+});
+var primaryFile = args.opt.primary;
+var secondaryFile = args.opt.secondary;
+fs.readFile(primaryFile, fileType, function (err, primaryContent) {
+  errorOccurred(err, opts);
+  if (!primaryContent || primaryContent.length === 0) return console.error("existing addresses.json file has no content");
+  fs.readFile(secondaryFile, fileType, function (err, secondaryContent) {
+    errorOccurred(err, opts);
+    if (!secondaryContent || secondaryContent.length === 0) return console.error("new addresses.json file has no content");
+    console.log(mergeJsonFiles(primaryContent, secondaryContent));
+  });
+});
+
+


### PR DESCRIPTION
new merge json files script.
modified docker file to default addresses.json and upload-block-numbers.json file to {} so that only the  docker image's networkId exists after deploy
use new merge json files in copy docker files script.
don't copy addresses or blocks if there's an error from the merge json files script. 
