### PR TITLE
removing references to :latest when copying files

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "docker:geth:pop": "scripts/docker/run-background.sh augurproject/dev-pop-geth",
     "docker:geth:pop-normal-time": "scripts/docker/run-background.sh augurproject/dev-pop-normtime-geth",
     "docker:geth:attach": "docker run --rm --net host -it ethereum/client-go attach rpc:http://127.0.0.1:8545",
-    "docker:geth:files": "scripts/copy-docker-files.sh augurproject/dev-pop-geth:latest"
+    "docker:geth:files": "scripts/copy-docker-files.sh augurproject/dev-pop-geth:core-$(npm view augur-core version)"
   },
   "dependencies": {
     "async": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "release:major": "npm version major && git push && git push --tags && npm publish",
     "docker:build": "scripts/docker/build.sh",
     "docker:build-and-push": "npm run docker:build && scripts/docker/push.sh",
-    "docker:pull": "docker pull augurproject/dev-node-parity:latest && docker pull augurproject/dev-node-geth:latest && docker pull augurproject/dev-pop-geth:latest && docker pull augurproject/dev-pop-normtime-geth:latest",
+    "docker:pull": "docker pull augurproject/dev-node-parity:latest && docker pull augurproject/dev-node-geth:latest && docker pull augurproject/dev-pop-geth:core-$(npm view augur-core version) && docker pull augurproject/dev-pop-normtime-geth:latest",
     "docker:geth": "docker run -e GETH_VERBOSITY=4 -it -p 8545:8545 -p 8546:8546 -v $HOME/docker:/geth/chain augurproject/dev-node-geth:latest",
     "docker:geth:pop": "scripts/docker/run-background.sh augurproject/dev-pop-geth",
     "docker:geth:pop-normal-time": "scripts/docker/run-background.sh augurproject/dev-pop-normtime-geth",


### PR DESCRIPTION
grab the files from the correct docker based on augur-core version, not from :latest