### PR TITLE
Use SIGTERM to gracefully exit geth

### DIFF
--- a/scripts/run-geth-and-deploy.sh
+++ b/scripts/run-geth-and-deploy.sh
@@ -10,4 +10,4 @@ sleep 10s
 
 node scripts/dp deploy
 
-$(kill -9 $(pidof geth))
+$(kill -TERM $(pidof geth))


### PR DESCRIPTION
So that after POP images are loaded we actually let geth commit to disk