### PR TITLE
fix issue with using negative outcomes to report

### DIFF
--- a/scripts/flash/designated-report.js
+++ b/scripts/flash/designated-report.js
@@ -39,6 +39,7 @@ function designateReport(augur, args, auth, callback) {
         return callback(err);
       }
       var market = marketsInfo[0];
+      outcome = outcome.replace(/\"/g, "");
       if (market.marketType === "scalar" && (new BigNumber(market.minPrice).gt(new BigNumber(parseInt(outcome, 10))))) {
         console.log(chalk.red("Scalar price is below min price"));
         callback("Error");

--- a/scripts/flash/designated-report.js
+++ b/scripts/flash/designated-report.js
@@ -27,14 +27,19 @@ function designateReport(augur, args, auth, callback) {
   var marketId = args.opt.marketId;
   var outcome = args.opt.outcome;
   var invalid = args.opt.invalid;
+
   getRepTokens(augur, amount, auth, function (err) {
     if (err) {
       console.log(chalk.red(err));
       return callback(err);
     }
     augur.markets.getMarketsInfo({ marketIds: [marketId] }, function (err, marketsInfo) {
+      if (err) {
+        console.log(chalk.red(err));
+        return callback(err);
+      }
       var market = marketsInfo[0];
-      if (market.marketType === "scalar" && (new BigNumber(market.minPrice).gt(new BigNumber(outcome)))) {
+      if (market.marketType === "scalar" && (new BigNumber(market.minPrice).gt(new BigNumber(parseInt(outcome, 10))))) {
         console.log(chalk.red("Scalar price is below min price"));
         callback("Error");
       }

--- a/scripts/flash/get-payout-numerators.js
+++ b/scripts/flash/get-payout-numerators.js
@@ -26,6 +26,7 @@ function getPayoutNumerators(market, selectedOutcome, invalid) {
   } else if (isScalar) {
 		// selectedOutcome must be a BN as string
     var priceRange = maxPrice.minus(minPrice);
+    selectedOutcome = selectedOutcome.replace(/\"/g, "");
     var reportNormalizedToZero = createBigNumber(selectedOutcome).minus(minPrice);
     var longPayout = reportNormalizedToZero.times(numTicks).dividedBy(priceRange);
     var shortPayout = numTicks.minus(longPayout);

--- a/scripts/flash/index.js
+++ b/scripts/flash/index.js
@@ -47,7 +47,7 @@ var methods = {
     opts: {
       help: {flag: true, short: "h", help: "This help, REP is given to user if needed" },
       marketId: { required: true, short: "m", help: "Required market id" },
-      outcome: { required: true, short: "o", help: "Outcome, sets outcome to use, can be overridden by invalid flag" },
+      outcome: { required: true, short: "o", help: "Outcome, sets outcome to use, can be overridden by invalid flag, negative outcome use \\\"-10\\\"" },
       invalid: { flag: true, short: "i", help: "Overrides outcome to pass invalid" },
     },
   },
@@ -56,7 +56,7 @@ var methods = {
     opts: {
       help: {flag: true, short: "h", help: "This help, used for Open Reporting" },
       marketId: { required: true, short: "m", help: "Required market id" },
-      outcome: { required: true, short: "o", help: "Outcome, sets outcome to use, can be overridden by invalid flag" },
+      outcome: { required: true, short: "o", help: "Outcome, sets outcome to use, can be overridden by invalid flag, negative outcome use \\\"-10\\\"" },
       invalid: { flag: true, short: "i", help: "Overrides outcome to pass invalid" },
     },
   },
@@ -65,7 +65,7 @@ var methods = {
     opts: {
       help: {flag: true, short: "h", help: "This help, push time and dispute this market" },
       marketId: { required: true, short: "m", help: "Required market id" },
-      outcome: { required: true, short: "o", help: "Outcome, sets outcome to use, can be overridden by invalid flag" },
+      outcome: { required: true, short: "o", help: "Outcome, sets outcome to use, can be overridden by invalid flag, negative outcome use \\\"-10\\\"" },
       amount: { short: "a", help: "Optional: amount of REP to dispute with" },
       invalid: { flag: true, short: "i", help: "Overrides outcome to pass invalid" },
     },
@@ -124,7 +124,7 @@ var methods = {
     opts: {
       help: {flag: true, short: "h", help: "This help, script approves user if needed" },
       marketId: { required: true, short: "m", help: "Required market id" },
-      outcome: { required: true, short: "o", help: "Outcome to fill order on" },
+      outcome: { required: true, short: "o", help: "Outcome to fill order on, negative outcome use \\\"-10\\\"" },
       orderType: {required: true, short: "t", help: "Order type ('buy' | 'sell')"},
     },
   },


### PR DESCRIPTION
Saw an issue where negative numbers couldn't be parsed by options parser. Added \"-10\" format to help for outcome option
Needed to trim off \" before using outcome in big number calculation.