### PR TITLE
Changing gas estimates to strings for claimReportingFees functions

### DIFF
--- a/src/reporting/claim-reporting-fees-forked-market.js
+++ b/src/reporting/claim-reporting-fees-forked-market.js
@@ -12,16 +12,12 @@ var PARALLEL_LIMIT = require("../constants").PARALLEL_LIMIT;
  * @typedef {Object} CrowdsourcerState
  * @property {string} crowdsourcerId Ethereum contract address of a DisputeCrowdsourcer belonging to a Forked Market, as a hexadecimal string.
  * @property {boolean} needsFork Whether `DisputeCrowdsourcer.fork` has been called successfully on the DisputeCrowdsourcer.
- * @property {BigNumber} unclaimedEthFees Amount of unclaimed ETH the user can redeem from the DisputeCrowdsourcer.
- * @property {BigNumber} unclaimedRepStaked Amount of unclaimed REP the user has staked in the DisputeCrowdsourcer.
  */
 
 /**
  * @typedef {Object} InitialReporterState
  * @property {string} initialReporterId Ethereum contract address of the InitialReporter belonging to a Forked Market, as a hexadecimal string.
  * @property {boolean} needsFork Whether `InitialReporter.fork` has been called successfully on the InitialReporter.
- * @property {BigNumber} unclaimedEthFees Amount of unclaimed ETH the user can redeem from the InitialReporter.
- * @property {BigNumber} unclaimedRepStaked Amount of unclaimed REP the user has staked in the InitialReporter.
  */
 
 /**
@@ -219,6 +215,13 @@ function claimReportingFeesForkedMarket(p) {
                                 .plus(gasEstimates.totals.initialReporterForkAndRedeem)
                                 .plus(gasEstimates.totals.crowdsourcerRedeem)
                                 .plus(gasEstimates.totals.initialReporterRedeem);
+
+      gasEstimates.totals.crowdsourcerForkAndRedeem = gasEstimates.totals.crowdsourcerForkAndRedeem.toString();
+      gasEstimates.totals.initialReporterForkAndRedeem = gasEstimates.totals.initialReporterForkAndRedeem.toString();
+      gasEstimates.totals.crowdsourcerRedeem = gasEstimates.totals.crowdsourcerRedeem.toString();
+      gasEstimates.totals.initialReporterRedeem = gasEstimates.totals.initialReporterRedeem.toString();
+      gasEstimates.totals.all =  gasEstimates.totals.all.toString();
+
       result = {
         gasEstimates: gasEstimates,
       };

--- a/src/reporting/claim-reporting-fees-nonforked-markets.js
+++ b/src/reporting/claim-reporting-fees-nonforked-markets.js
@@ -12,25 +12,12 @@ var PARALLEL_LIMIT = require("../constants").PARALLEL_LIMIT;
  * @typedef {Object} CrowdsourcerState
  * @property {string} crowdsourcerId Ethereum contract address of a DisputeCrowdsourcer belonging to a Forked Market, as a hexadecimal string.
  * @property {boolean} needsFork Whether `DisputeCrowdsourcer.fork` has been called successfully on the DisputeCrowdsourcer.
- * @property {BigNumber} unclaimedEthFees Amount of unclaimed ETH the user can redeem from the DisputeCrowdsourcer.
- * @property {BigNumber} unclaimedRepStaked Amount of unclaimed REP the user has staked in the DisputeCrowdsourcer.
  */
 
 /**
  * @typedef {Object} InitialReporterState
  * @property {string} initialReporterId Ethereum contract address of the InitialReporter belonging to a Forked Market, as a hexadecimal string.
  * @property {boolean} needsFork Whether `InitialReporter.fork` has been called successfully on the InitialReporter.
- * @property {BigNumber} unclaimedEthFees Amount of unclaimed ETH the user can redeem from the InitialReporter.
- * @property {BigNumber} unclaimedRepStaked Amount of unclaimed REP the user has staked in the InitialReporter.
- */
-
-/**
- * @typedef {Object} ForkedMarket
- * @property {string} marketId Ethereum contract address of the Forked Market, as a hexadecimal string.
- * @property {string} universeAddress Ethereum contract address of Universe to which the Forked Market belongs, as a hexadecimal string.
- * @property {boolen} isFinalized Whether the Forked Market has been Finalized (i.e., the function `Market.finalize` has been called on it successfully).
- * @property {Array.<CrowdsourcerState>} crowdsourcers Array of objects containing information about the Forked Market’s DisputeCrowdsourcers.
- * @property {InitialReporterState|null} initialReporter Object containing information about the Forked Market’s InitialReporter.
  */
 
  /**
@@ -41,7 +28,7 @@ var PARALLEL_LIMIT = require("../constants").PARALLEL_LIMIT;
  * @property {boolean} isMigrated Whether the non-Forked Market has been migrated to the Child Universe of its original Universe (i.e., its `Market.isMigrated` function has been called successfully).
  * @property {boolean} isFinalized Whether the non-Forked Market has been Finalized (i.e., its `Market.finalize` function has been called successfully).
  * @property {Array.<string>} crowdsourcers Array of Ethereum contract addresses of the non-Forked Market's DisputeCrowdsourcers, as hexadecimal strings.
- * @property {string|null} initialReporterId Ethereum contract address of the non-Forked Market's InitialReporter, as a hexadecimal string.
+ * @property {string|null} initialReporter Ethereum contract address of the non-Forked Market's InitialReporter, as a hexadecimal string.
  */
 
 function redeemContractFees(p, payload, successfulTransactions, failedTransactions, gasEstimates) {
@@ -168,6 +155,13 @@ function redeemContractFees(p, payload, successfulTransactions, failedTransactio
                                 .plus(gasEstimates.totals.feeWindowRedeem)
                                 .plus(gasEstimates.totals.crowdsourcerRedeem)
                                 .plus(gasEstimates.totals.initialReporterRedeem);
+
+      gasEstimates.totals.disavowCrowdsourcers = gasEstimates.totals.disavowCrowdsourcers.toString();
+      gasEstimates.totals.feeWindowRedeem = gasEstimates.totals.feeWindowRedeem.toString();
+      gasEstimates.totals.crowdsourcerRedeem = gasEstimates.totals.crowdsourcerRedeem.toString();
+      gasEstimates.totals.initialReporterRedeem = gasEstimates.totals.initialReporterRedeem.toString();
+      gasEstimates.totals.all =  gasEstimates.totals.all.toString();
+
       result = {
         gasEstimates: gasEstimates,
       };
@@ -204,7 +198,6 @@ function redeemContractFees(p, payload, successfulTransactions, failedTransactio
  * @param {Object} p Parameters object.
  * @param {string} p.redeemer Ethereum address attempting to redeem reporting fees, as a hexadecimal string.
  * @param {Array.<string>} p.feeWindows Array of FeeWindow contract addresses which to claim reporting fees, as hexadecimal strings.
- * @param {ForkedMarket} p.forkedMarket Object containing information about the Forked Market in which the user has unclaimed fees in the Parent Universe(if there is one).
  * @param {Array.<NonforkedMarket>} p.nonforkedMarkets Array containing objects with information about the non-Forked Markets in which the user has unclaimed fees.
  * @param {boolean} p.estimateGas Whether to return gas estimates for the transactions instead of actually making the transactions.
  * @param {{signer: buffer|function, accountType: string}=} p.meta Authentication metadata for raw transactions.

--- a/test/unit/reporting/claim-reporting-fees-forked-market-initial-reporter-fork-and-redeem.js
+++ b/test/unit/reporting/claim-reporting-fees-forked-market-initial-reporter-fork-and-redeem.js
@@ -175,14 +175,14 @@ describe("reporting/claim-reporting-fees-forked-market", function () {
               ],
               initialReporterRedeem: [],
               totals: {
-                crowdsourcerForkAndRedeem: crowdsourcerForkAndRedeemTotal,
-                initialReporterForkAndRedeem: initialReporterForkAndRedeemTotal,
-                crowdsourcerRedeem: crowdsourcerRedeemTotal,
-                initialReporterRedeem: initialReporterRedeemTotal,
+                crowdsourcerForkAndRedeem: crowdsourcerForkAndRedeemTotal.toString(),
+                initialReporterForkAndRedeem: initialReporterForkAndRedeemTotal.toString(),
+                crowdsourcerRedeem: crowdsourcerRedeemTotal.toString(),
+                initialReporterRedeem: initialReporterRedeemTotal.toString(),
                 all: crowdsourcerForkAndRedeemTotal
                     .plus(initialReporterForkAndRedeemTotal)
                     .plus(crowdsourcerRedeemTotal)
-                    .plus(initialReporterRedeemTotal),
+                    .plus(initialReporterRedeemTotal).toString(),
               },
             },
           };

--- a/test/unit/reporting/claim-reporting-fees-forked-market-initial-reporter-redeem.js
+++ b/test/unit/reporting/claim-reporting-fees-forked-market-initial-reporter-redeem.js
@@ -175,14 +175,14 @@ describe("reporting/claim-reporting-fees-forked-market", function () {
                 { address: "0xf1Add00000000000000000000000000000000000", estimate: new BigNumber(INITIAL_REPORTER_REDEEM_GAS_ESTIMATE, 16) },
               ],
               totals: {
-                crowdsourcerForkAndRedeem: crowdsourcerForkAndRedeemTotal,
-                initialReporterForkAndRedeem: initialReporterForkAndRedeemTotal,
-                crowdsourcerRedeem: crowdsourcerRedeemTotal,
-                initialReporterRedeem: initialReporterRedeemTotal,
+                crowdsourcerForkAndRedeem: crowdsourcerForkAndRedeemTotal.toString(),
+                initialReporterForkAndRedeem: initialReporterForkAndRedeemTotal.toString(),
+                crowdsourcerRedeem: crowdsourcerRedeemTotal.toString(),
+                initialReporterRedeem: initialReporterRedeemTotal.toString(),
                 all: crowdsourcerForkAndRedeemTotal
                     .plus(initialReporterForkAndRedeemTotal)
                     .plus(crowdsourcerRedeemTotal)
-                    .plus(initialReporterRedeemTotal),
+                    .plus(initialReporterRedeemTotal).toString(),
               },
             },
           };

--- a/test/unit/reporting/claim-reporting-fees-nonforked-markets-forked-market.js
+++ b/test/unit/reporting/claim-reporting-fees-nonforked-markets-forked-market.js
@@ -341,14 +341,14 @@ describe("reporting/claim-reporting-fees-nonforked-markets", function () {
                 { address: "0x0f1Add0000000000000000000000000000000016", estimate: new BigNumber(INITIAL_REPORTER_REDEEM_GAS_ESTIMATE, 16) },
               ],
               totals: {
-                disavowCrowdsourcers: disavowCrowdsourcersTotal,
-                feeWindowRedeem: feeWindowRedeemTotal,
-                crowdsourcerRedeem: crowdsourcerRedeemTotal,
-                initialReporterRedeem: initialReporterRedeemTotal,
+                disavowCrowdsourcers: disavowCrowdsourcersTotal.toString(),
+                feeWindowRedeem: feeWindowRedeemTotal.toString(),
+                crowdsourcerRedeem: crowdsourcerRedeemTotal.toString(),
+                initialReporterRedeem: initialReporterRedeemTotal.toString(),
                 all: disavowCrowdsourcersTotal
                     .plus(feeWindowRedeemTotal)
                     .plus(crowdsourcerRedeemTotal)
-                    .plus(initialReporterRedeemTotal),
+                    .plus(initialReporterRedeemTotal).toString(),
               },
             },
           };

--- a/test/unit/reporting/claim-reporting-fees-nonforked-markets-no-forked-market.js
+++ b/test/unit/reporting/claim-reporting-fees-nonforked-markets-no-forked-market.js
@@ -308,14 +308,14 @@ describe("reporting/claim-reporting-fees-nonforked-markets", function () {
                 { address: "0x0f1Add0000000000000000000000000000000008", estimate: new BigNumber(INITIAL_REPORTER_REDEEM_GAS_ESTIMATE, 16) },
               ],
               totals: {
-                disavowCrowdsourcers: disavowCrowdsourcersTotal,
-                feeWindowRedeem: feeWindowRedeemTotal,
-                crowdsourcerRedeem: crowdsourcerRedeemTotal,
-                initialReporterRedeem: initialReporterRedeemTotal,
+                disavowCrowdsourcers: disavowCrowdsourcersTotal.toString(),
+                feeWindowRedeem: feeWindowRedeemTotal.toString(),
+                crowdsourcerRedeem: crowdsourcerRedeemTotal.toString(),
+                initialReporterRedeem: initialReporterRedeemTotal.toString(),
                 all: disavowCrowdsourcersTotal
                     .plus(feeWindowRedeemTotal)
                     .plus(crowdsourcerRedeemTotal)
-                    .plus(initialReporterRedeemTotal),
+                    .plus(initialReporterRedeemTotal).toString(),
               },
             },
           };


### PR DESCRIPTION
The gas estimates were previously getting returned as BigNumbers, but they should be returned as strings. Also updated misc. JSDoc info to be correct.

NOTE: This change does not cause problems for the modals that are displayed when claiming reporting fees. The UI code was already calling `.toString` on the gas estimates, and I confirmed they are still displayed as expected in the modals.