### PR TITLE
Tinybike/ch11178/simulatetrade doesn t handle position reversal

### DIFF
--- a/test/unit/trading/simulation/simulate-trade.js
+++ b/test/unit/trading/simulation/simulate-trade.js
@@ -15,6 +15,85 @@ describe("trading/simulation/simulate-trade", function () {
       }
     });
   };
+  // If I have 100 YES and sell 101 it will say I have otherSharesDepleted of 101 shares and a balance of 99
+  test({
+    description: "position reversal (long to short)",
+    params: {
+      orderType: 1,
+      outcome: 1,
+      shares: "101",
+      shareBalances: ["0", "100"],
+      tokenBalance: "0",
+      userAddress: "USER_ADDRESS",
+      minPrice: "0",
+      maxPrice: "1",
+      price: "0.7",
+      marketCreatorFeeRate: "0",
+      reportingFeeRate: "0.01",
+      shouldCollectReportingFees: 1,
+      singleOutcomeOrderBook: {
+        buy: {
+          BID_0: {
+            amount: "101",
+            fullPrecisionPrice: "0.7",
+            sharesEscrowed: "0",
+            owner: "OWNER_ADDRESS",
+          },
+        },
+        sell: {},
+      },
+    },
+    assertions: function (output) {
+      assert.deepEqual(output,  {
+        sharesFilled: "101",
+        settlementFees: "0",
+        worstCaseFees: "0",
+        sharesDepleted: "100",
+        otherSharesDepleted: "0",
+        tokensDepleted: "0.3",
+        shareBalances: ["0", "0"],
+      });
+    },
+  });
+  test({
+    description: "position reversal (short to long)",
+    params: {
+      orderType: 0,
+      outcome: 1,
+      shares: "101",
+      shareBalances: ["100", "0"],
+      tokenBalance: "0",
+      userAddress: "USER_ADDRESS",
+      minPrice: "0",
+      maxPrice: "1",
+      price: "0.7",
+      marketCreatorFeeRate: "0",
+      reportingFeeRate: "0.01",
+      shouldCollectReportingFees: 1,
+      singleOutcomeOrderBook: {
+        buy: {},
+        sell: {
+          ASK_0: {
+            amount: "101",
+            fullPrecisionPrice: "0.7",
+            sharesEscrowed: "101",
+            owner: "OWNER_ADDRESS",
+          },
+        },
+      },
+    },
+    assertions: function (output) {
+      assert.deepEqual(output, {
+        sharesFilled: "101",
+        settlementFees: "0.3",
+        worstCaseFees: "0.3",
+        sharesDepleted: "0",
+        otherSharesDepleted: "100",
+        tokensDepleted: "0.7",
+        shareBalances: ["0", "0"],
+      });
+    },
+  });
   test({
     description: "simulate trade (buy)",
     params: {

--- a/test/unit/trading/simulation/simulate-trade.js
+++ b/test/unit/trading/simulation/simulate-trade.js
@@ -15,85 +15,6 @@ describe("trading/simulation/simulate-trade", function () {
       }
     });
   };
-  // If I have 100 YES and sell 101 it will say I have otherSharesDepleted of 101 shares and a balance of 99
-  test({
-    description: "position reversal (long to short)",
-    params: {
-      orderType: 1,
-      outcome: 1,
-      shares: "101",
-      shareBalances: ["0", "100"],
-      tokenBalance: "0",
-      userAddress: "USER_ADDRESS",
-      minPrice: "0",
-      maxPrice: "1",
-      price: "0.7",
-      marketCreatorFeeRate: "0",
-      reportingFeeRate: "0.01",
-      shouldCollectReportingFees: 1,
-      singleOutcomeOrderBook: {
-        buy: {
-          BID_0: {
-            amount: "101",
-            fullPrecisionPrice: "0.7",
-            sharesEscrowed: "0",
-            owner: "OWNER_ADDRESS",
-          },
-        },
-        sell: {},
-      },
-    },
-    assertions: function (output) {
-      assert.deepEqual(output,  {
-        sharesFilled: "101",
-        settlementFees: "0",
-        worstCaseFees: "0",
-        sharesDepleted: "100",
-        otherSharesDepleted: "0",
-        tokensDepleted: "0.3",
-        shareBalances: ["0", "0"],
-      });
-    },
-  });
-  test({
-    description: "position reversal (short to long)",
-    params: {
-      orderType: 0,
-      outcome: 1,
-      shares: "101",
-      shareBalances: ["100", "0"],
-      tokenBalance: "0",
-      userAddress: "USER_ADDRESS",
-      minPrice: "0",
-      maxPrice: "1",
-      price: "0.7",
-      marketCreatorFeeRate: "0",
-      reportingFeeRate: "0.01",
-      shouldCollectReportingFees: 1,
-      singleOutcomeOrderBook: {
-        buy: {},
-        sell: {
-          ASK_0: {
-            amount: "101",
-            fullPrecisionPrice: "0.7",
-            sharesEscrowed: "101",
-            owner: "OWNER_ADDRESS",
-          },
-        },
-      },
-    },
-    assertions: function (output) {
-      assert.deepEqual(output, {
-        sharesFilled: "101",
-        settlementFees: "0.3",
-        worstCaseFees: "0.3",
-        sharesDepleted: "0",
-        otherSharesDepleted: "100",
-        tokensDepleted: "0.7",
-        shareBalances: ["0", "0"],
-      });
-    },
-  });
   test({
     description: "simulate trade (buy)",
     params: {
@@ -183,6 +104,84 @@ describe("trading/simulation/simulate-trade", function () {
         sharesDepleted: "0",
         tokensDepleted: "0.9",
         shareBalances: ["0", "5"],
+      });
+    },
+  });
+  test({
+    description: "position reversal (long to short)",
+    params: {
+      orderType: 1,
+      outcome: 1,
+      shares: "101",
+      shareBalances: ["0", "100"],
+      tokenBalance: "0",
+      userAddress: "USER_ADDRESS",
+      minPrice: "0",
+      maxPrice: "1",
+      price: "0.7",
+      marketCreatorFeeRate: "0",
+      reportingFeeRate: "0.01",
+      shouldCollectReportingFees: 1,
+      singleOutcomeOrderBook: {
+        buy: {
+          BID_0: {
+            amount: "101",
+            fullPrecisionPrice: "0.7",
+            sharesEscrowed: "0",
+            owner: "OWNER_ADDRESS",
+          },
+        },
+        sell: {},
+      },
+    },
+    assertions: function (output) {
+      assert.deepEqual(output,  {
+        sharesFilled: "101",
+        settlementFees: "0",
+        worstCaseFees: "0",
+        sharesDepleted: "100",
+        otherSharesDepleted: "0",
+        tokensDepleted: "0.3",
+        shareBalances: ["0", "0"],
+      });
+    },
+  });
+  test({
+    description: "position reversal (short to long)",
+    params: {
+      orderType: 0,
+      outcome: 1,
+      shares: "101",
+      shareBalances: ["100", "0"],
+      tokenBalance: "0",
+      userAddress: "USER_ADDRESS",
+      minPrice: "0",
+      maxPrice: "1",
+      price: "0.7",
+      marketCreatorFeeRate: "0",
+      reportingFeeRate: "0.01",
+      shouldCollectReportingFees: 1,
+      singleOutcomeOrderBook: {
+        buy: {},
+        sell: {
+          ASK_0: {
+            amount: "101",
+            fullPrecisionPrice: "0.7",
+            sharesEscrowed: "101",
+            owner: "OWNER_ADDRESS",
+          },
+        },
+      },
+    },
+    assertions: function (output) {
+      assert.deepEqual(output, {
+        sharesFilled: "101",
+        settlementFees: "0.3",
+        worstCaseFees: "0.3",
+        sharesDepleted: "0",
+        otherSharesDepleted: "100",
+        tokensDepleted: "0.7",
+        shareBalances: ["0", "0"],
       });
     },
   });


### PR DESCRIPTION
Wasn't able to repro [ch11178](https://app.clubhouse.io/augur/story/11178/simulatetrade-doesn-t-handle-position-reversal), but went ahead and added a couple test cases for position reversals just to be sure.