### PR TITLE
by default do not snap num ticks. purely a UI input nice-ity

### DIFF
--- a/src/trading/calculate-trade-cost.js
+++ b/src/trading/calculate-trade-cost.js
@@ -35,7 +35,7 @@ function calculateTradeCost(p) {
   var displayRange =  maxDisplayPrice.minus(minDisplayPrice);
   var tickSize = calculateTickSize(numTicks, p.minDisplayPrice, p.maxDisplayPrice);
   var onChainPrice = convertDisplayPriceToOnChainPrice(displayPrice, minDisplayPrice, tickSize);
-  var onChainAmount = convertDisplayAmountToOnChainAmount(displayAmount, displayRange, numTicks);
+  var onChainAmount = convertDisplayAmountToOnChainAmount(displayAmount, displayRange, numTicks, true);
   var onChainSharesProvided = convertDisplayAmountToOnChainAmount(sharesProvided, displayRange, numTicks);
   var onChainAmountForPrice = onChainAmount.minus(onChainSharesProvided);
   var cost;

--- a/src/trading/calculate-trade-cost.js
+++ b/src/trading/calculate-trade-cost.js
@@ -35,7 +35,7 @@ function calculateTradeCost(p) {
   var displayRange =  maxDisplayPrice.minus(minDisplayPrice);
   var tickSize = calculateTickSize(numTicks, p.minDisplayPrice, p.maxDisplayPrice);
   var onChainPrice = convertDisplayPriceToOnChainPrice(displayPrice, minDisplayPrice, tickSize);
-  var onChainAmount = convertDisplayAmountToOnChainAmount(displayAmount, displayRange, numTicks, true);
+  var onChainAmount = convertDisplayAmountToOnChainAmount(displayAmount, displayRange, numTicks);
   var onChainSharesProvided = convertDisplayAmountToOnChainAmount(sharesProvided, displayRange, numTicks);
   var onChainAmountForPrice = onChainAmount.minus(onChainSharesProvided);
   var cost;

--- a/src/utils/convert-display-amount-to-on-chain-amount.js
+++ b/src/utils/convert-display-amount-to-on-chain-amount.js
@@ -1,12 +1,8 @@
 "use strict";
 
-var BigNumber = require("bignumber.js");
 var speedomatic = require("speedomatic");
 
-function convertDisplayAmountToOnChainAmount(displayAmount, displayRange, numTicks, snapNumTicks) {
-  if (snapNumTicks && (numTicks.eq(10002) || numTicks.eq(10003))) {
-    numTicks = new BigNumber(10000, 10);
-  }
+function convertDisplayAmountToOnChainAmount(displayAmount, displayRange, numTicks) {
   var tickSize = displayRange.dividedBy(numTicks);
   return speedomatic.fix(displayAmount).times(tickSize);
 }

--- a/src/utils/convert-display-amount-to-on-chain-amount.js
+++ b/src/utils/convert-display-amount-to-on-chain-amount.js
@@ -3,8 +3,8 @@
 var BigNumber = require("bignumber.js");
 var speedomatic = require("speedomatic");
 
-function convertDisplayAmountToOnChainAmount(displayAmount, displayRange, numTicks) {
-  if (numTicks.eq(10002) || numTicks.eq(10003)) {
+function convertDisplayAmountToOnChainAmount(displayAmount, displayRange, numTicks, snapNumTicks) {
+  if (snapNumTicks && (numTicks.eq(10002) || numTicks.eq(10003))) {
     numTicks = new BigNumber(10000, 10);
   }
   var tickSize = displayRange.dividedBy(numTicks);

--- a/test/unit/trading/calculate-trade-cost.js
+++ b/test/unit/trading/calculate-trade-cost.js
@@ -86,8 +86,8 @@ describe("trading/calculate-trade-cost", function () {
       numTicks: "10002",
     },
     assertions: function (tradeCost) {
-      assert.strictEqual(tradeCost.cost.toFixed(), "75020000000000000");
-      assert.strictEqual(tradeCost.onChainAmount.toFixed(), "10000000000000");
+      assert.strictEqual(tradeCost.cost.toFixed(), "75004999000199961");
+      assert.strictEqual(tradeCost.onChainAmount.toFixed(), "9998000399920");
       assert.strictEqual(tradeCost.onChainPrice.toFixed(), "7502");
     },
   });
@@ -102,8 +102,8 @@ describe("trading/calculate-trade-cost", function () {
       numTicks: "10002",
     },
     assertions: function (tradeCost) {
-      assert.strictEqual(tradeCost.cost.toFixed(), "25010000000000000");
-      assert.strictEqual(tradeCost.onChainAmount.toFixed(), "10000000000000");
+      assert.strictEqual(tradeCost.cost.toFixed(), "25004999000199961");
+      assert.strictEqual(tradeCost.onChainAmount.toFixed(), "9998000399920");
       assert.strictEqual(tradeCost.onChainPrice.toFixed(), "7501");
     },
   });


### PR DESCRIPTION
The only reason to do this snap is to covert human input into a nice even amount. Everywhere else we need precision.

This fixes the current issue with buying out a cat 7 order book then selling held shares

Update: On reflection I believe the snapping behavior is entirely an error and am just removing it here (confirmed the bug is still fixed in the new version). Whatever purchase from converting from display amount to on chain _should_ then appear everywhere in the UI as the originally entered display amount, so this would only fix display issues if we were incorrectly converting to display somewhere.