### PR TITLE
dont pass worse order ids to placeTrade

### DIFF
--- a/src/trading/place-trade.js
+++ b/src/trading/place-trade.js
@@ -36,7 +36,7 @@ function placeTrade(p) {
       _price: p.limitPrice,
       _fxpAmount: p.amount,
       _betterOrderId: (betterWorseOrders || {}).betterOrderId || "0x0",
-      _worseOrderId: (betterWorseOrders || {}).worseOrderId || "0x0",
+      _worseOrderId: "0x0",
     }));
   });
 }

--- a/test/unit/trading/place-trade.js
+++ b/test/unit/trading/place-trade.js
@@ -119,7 +119,7 @@ describe("trading/place-trade", function () {
         assert.strictEqual(p._price, "2");
         assert.strictEqual(p._tradeGroupId, "0x1");
         assert.strictEqual(p._betterOrderId, "BETTER_ORDER_ID");
-        assert.strictEqual(p._worseOrderId, "WORSE_ORDER_ID");
+        assert.strictEqual(p._worseOrderId, "0x0");
         p.onSent({ hash: "TRANSACTION_HASH" });
         p.onSuccess({ hash: "TRANSACTION_HASH" });
       },


### PR DESCRIPTION
Passing a worse order id to placeTrade is potentially very fail prone since we may end up buying the order id we're passing. The better order id will always be a valid start point though unless someone else buys that order id first (in which case we'd fail anyway)