### PR TITLE
round down when calculating payout numerators for invalid

### DIFF
--- a/scripts/flash/get-payout-numerators.js
+++ b/scripts/flash/get-payout-numerators.js
@@ -20,7 +20,7 @@ function getPayoutNumerators(market, selectedOutcome, invalid) {
   var isScalar = market.marketType === "scalar";
 
   if (invalid) {
-    var equalValue = createBigNumber(numTicks).dividedBy(market.numOutcomes);
+    var equalValue = createBigNumber(numTicks).dividedBy(market.numOutcomes).dp(0, BigNumber.ROUND_DOWN);
     return Array(market.numOutcomes).fill(equalValue);
 
   } else if (isScalar) {


### PR DESCRIPTION
fix calculating payout numerators for invalid categorical 3,6,7 markets.