### PR TITLE
stream process augur node bulk sync

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -225,7 +225,7 @@ export class Augur {
     [functionName: string]: ApiFunction,
   };
   public events: {
-    getAllAugurLogs: ApiFunction;
+    getAllAugurLogs: (p: ApiParams, batchCallback: ApiCallback, finalCallback: (err: Error|null) => void) => any;
     startBlockListeners(blockCallbacks: BlockSubscriptionCallbacks): boolean;
     stopBlockListeners(): boolean;
     startBlockchainEventListeners(eventCallbacks: EventSubscriptionCallbacksKeyedByContract, startingBlockNumber: number, onSetupComplete?: (err: Error|null) => void): void;

--- a/test/unit/events/get-all-augur-logs.js
+++ b/test/unit/events/get-all-augur-logs.js
@@ -4,6 +4,7 @@
 
 var assert = require("chai").assert;
 var proxyquire = require("proxyquire").noPreserveCache();
+var sinon = require("sinon");
 
 describe("events/get-all-augur-logs", function () {
   var test = function (t) {
@@ -16,8 +17,12 @@ describe("events/get-all-augur-logs", function () {
         "../rpc-interface": t.stub.rpcInterface,
         "../utils/chunk-blocks": chunkBlocks,
       });
-      getAllAugurLogs(t.params, function (batchAugurLogs) {
-        t.assertions(batchAugurLogs);
+      var processBatchLogs = sinon.spy(function (batchAugurLogs) {
+        console.log("HHHH", processBatchLogs);
+        t.assertions(batchAugurLogs, processBatchLogs.callCount);
+      });
+      getAllAugurLogs(t.params, processBatchLogs, function (err) {
+        assert.ifError(err);
         done();
       });
     });
@@ -119,47 +124,54 @@ describe("events/get-all-augur-logs", function () {
         },
       },
     },
-    assertions: function (batchAugurLogs) {
-      // assert.isNull(err);
-      assert.deepEqual(batchAugurLogs, [
-        {
-          address: "0x000000000000000000000000000000000000000c",
-          testEventInputIndexed: "0x2000000000000000000000000000000000000000000000000000000000000000",
-          testEventInputData: "0x0000000000000000000000000000000000000001",
-          blockNumber: 14,
-          blockHash: "0x000000000000000000000000000000000000000000000000000000000000000b",
-          transactionHash: "0x000000000000000000000000000000000000000000000000000000000000000a",
-          transactionIndex: 0,
-          logIndex: 0,
-          removed: false,
-          contractName: "TestContractName",
-          eventName: "TestEventName",
-        }, {
-          address: "0x000000000000000000000000000000000000000c",
-          testEventInputIndexed: "0x3000000000000000000000000000000000000000000000000000000000000000",
-          testEventInputData: "0x0000000000000000000000000000000000000002",
-          blockNumber: 150,
-          blockHash: "0x00000000000000000000000000000000000000000000000000000000000000bb",
-          transactionHash: "0x00000000000000000000000000000000000000000000000000000000000000aa",
-          transactionIndex: 0,
-          logIndex: 0,
-          removed: false,
-          contractName: "TestContractName",
-          eventName: "TestEventName",
-        }, {
-          address: "0x000000000000000000000000000000000000000c",
-          testEventInputIndexed: "0x3000000000000000000000000000000000000000000000000000000000000000",
-          testEventInputData: "0x0000000000000000000000000000000000000003",
-          blockNumber: 151,
-          blockHash: "0x0000000000000000000000000000000000000000000000000000000000000bbb",
-          transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000aaa",
-          transactionIndex: 0,
-          logIndex: 0,
-          removed: false,
-          contractName: "TestContractName",
-          eventName: "TestEventName",
-        },
-      ]);
+    assertions: function (batchAugurLogs, callCount) {
+      switch (callCount) {
+        case 1:
+          assert.deepEqual(batchAugurLogs, [
+            {
+              address: "0x000000000000000000000000000000000000000c",
+              testEventInputIndexed: "0x2000000000000000000000000000000000000000000000000000000000000000",
+              testEventInputData: "0x0000000000000000000000000000000000000001",
+              blockNumber: 14,
+              blockHash: "0x000000000000000000000000000000000000000000000000000000000000000b",
+              transactionHash: "0x000000000000000000000000000000000000000000000000000000000000000a",
+              transactionIndex: 0,
+              logIndex: 0,
+              removed: false,
+              contractName: "TestContractName",
+              eventName: "TestEventName",
+            }]);
+          break;
+        case 2:
+          assert.deepEqual(batchAugurLogs, [{
+            address: "0x000000000000000000000000000000000000000c",
+            testEventInputIndexed: "0x3000000000000000000000000000000000000000000000000000000000000000",
+            testEventInputData: "0x0000000000000000000000000000000000000002",
+            blockNumber: 150,
+            blockHash: "0x00000000000000000000000000000000000000000000000000000000000000bb",
+            transactionHash: "0x00000000000000000000000000000000000000000000000000000000000000aa",
+            transactionIndex: 0,
+            logIndex: 0,
+            removed: false,
+            contractName: "TestContractName",
+            eventName: "TestEventName",
+          }, {
+            address: "0x000000000000000000000000000000000000000c",
+            testEventInputIndexed: "0x3000000000000000000000000000000000000000000000000000000000000000",
+            testEventInputData: "0x0000000000000000000000000000000000000003",
+            blockNumber: 151,
+            blockHash: "0x0000000000000000000000000000000000000000000000000000000000000bbb",
+            transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000aaa",
+            transactionIndex: 0,
+            logIndex: 0,
+            removed: false,
+            contractName: "TestContractName",
+            eventName: "TestEventName",
+          }]);
+          break;
+        default:
+          assert.fail();
+      }
     },
   });
 });

--- a/test/unit/events/get-all-augur-logs.js
+++ b/test/unit/events/get-all-augur-logs.js
@@ -16,8 +16,8 @@ describe("events/get-all-augur-logs", function () {
         "../rpc-interface": t.stub.rpcInterface,
         "../utils/chunk-blocks": chunkBlocks,
       });
-      getAllAugurLogs(t.params, function (err, allAugurLogs) {
-        t.assertions(err, allAugurLogs);
+      getAllAugurLogs(t.params, function (batchAugurLogs) {
+        t.assertions(batchAugurLogs);
         done();
       });
     });
@@ -119,9 +119,9 @@ describe("events/get-all-augur-logs", function () {
         },
       },
     },
-    assertions: function (err, allAugurLogs) {
-      assert.isNull(err);
-      assert.deepEqual(allAugurLogs, [
+    assertions: function (batchAugurLogs) {
+      // assert.isNull(err);
+      assert.deepEqual(batchAugurLogs, [
         {
           address: "0x000000000000000000000000000000000000000c",
           testEventInputIndexed: "0x2000000000000000000000000000000000000000000000000000000000000000",


### PR DESCRIPTION
getAllAugurLogs now emits batches of logs to one callback, and calls a finalCallback when it is finished. It is the recipient's (augur-node) responsibility to order the processing, as these will be fired async.