### PR TITLE
use hardcoded estimates by outcome number and limit fills per tx

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -104,6 +104,7 @@ module.exports = {
     8: new BigNumber("1292814", 10),
   },
   TRADE_GAS_BUFFER: new BigNumber("100000", 10),
+  MAX_FILLS_PER_TX: new BigNumber("3", 10),
   MAX_GAS_LIMIT_FOR_TRADE: new BigNumber("3500000", 10),
 
   BLOCKS_PER_CHUNK: 5760, // 1 days worth. 60*60*24/15 (seconds*minutes*hours/blocks_per_second)

--- a/src/constants.js
+++ b/src/constants.js
@@ -83,15 +83,28 @@ module.exports = {
   CREATE_SCALAR_MARKET_GAS: "0x5b8d80",
   CREATE_CATEGORICAL_MARKET_GAS: "0x5e3918",
 
-  CANCEL_ORDER_GAS: "0x5b8d80",
+  CANCEL_ORDER_GAS: "0xC9860",
 
-  // note: these numbers are wrong
-  CREATE_ORDER_GAS: "0x927C0",  // 600,000 is the ceiling for executing a single trade, from Alex 5.2.2018
-  FILL_ORDER_GAS: "0xdbba0",    // 900,000 is the ceiling for executing a single trade, from Alex 5.2.2018
-  MINIMUM_TRADE_GAS: new BigNumber("0x5e3918", 16),
-  GAS_BUFFER: new BigNumber("0x7A120", 16), // 500,000 gas buffer to account for fluctuation in the cost of fills
-  TRADE_GAS_LOWER_BOUND_MULTIPLIER: new BigNumber("0.4", 10),
-  TRADE_GAS_UPPER_BOUND_MULTIPLIER: new BigNumber("0.8", 10),
+  WORST_CASE_FILL: {
+    2: new BigNumber("933495", 10),
+    3: new BigNumber("1172245", 10),
+    4: new BigNumber("1410995", 10),
+    5: new BigNumber("1649744", 10),
+    6: new BigNumber("1888494", 10),
+    7: new BigNumber("2127244", 10),
+    8: new BigNumber("2365994", 10),
+  },
+  WORST_CASE_PLACE_ORDER: {
+    2: new BigNumber("695034", 10),
+    3: new BigNumber("794664", 10),
+    4: new BigNumber("894294", 10),
+    5: new BigNumber("993924", 10),
+    6: new BigNumber("1093554", 10),
+    7: new BigNumber("1193184", 10),
+    8: new BigNumber("1292814", 10),
+  },
+  TRADE_GAS_BUFFER: new BigNumber("100000", 10),
+  MAX_GAS_LIMIT_FOR_TRADE: new BigNumber("3500000", 10),
 
   BLOCKS_PER_CHUNK: 5760, // 1 days worth. 60*60*24/15 (seconds*minutes*hours/blocks_per_second)
   MAX_WEBSOCKET_FRAME_SIZE: 5760 * MAX_LOG_BYTES_PER_BLOCK, // Works out to under 1GB, extreme case but prevents error

--- a/src/trading/trade-until-amount-is-zero.js
+++ b/src/trading/trade-until-amount-is-zero.js
@@ -22,6 +22,7 @@ var constants = require("../constants");
  * @param {number} p._direction Order type (0 for "buy", 1 for "sell").
  * @param {string} p._market Market in which to trade, as a hex string.
  * @param {number} p._outcome Outcome ID to trade, must be an integer value on [0, 7].
+ * @param {number} p.numOutcomes The number of outcomes in the market, must be an integer value on [2, 8].
  * @param {string} p.minPrice The minimum display price for this market, as a base-10 string.
  * @param {string} p.maxPrice The maximum display price for this market, as a base-10 string.
  * @param {string=} p._tradeGroupId ID logged with each trade transaction (can be used to group trades client-side), as a hex string.
@@ -48,60 +49,57 @@ function tradeUntilAmountIsZero(p) {
   var onChainAmount = tradeCost.onChainAmount;
   var onChainPrice = tradeCost.onChainPrice;
   var cost = tradeCost.cost;
+  var numTradesPerTx = 0;
+  var gasLimit = p.doNotCreateOrders ? new BigNumber(0) : constants.WORST_CASE_PLACE_ORDER[p.numOutcomes];
+  while (gasLimit.plus(constants.WORST_CASE_FILL[p.numOutcomes]) < constants.MAX_GAS_LIMIT_FOR_TRADE) {
+    numTradesPerTx++;
+    gasLimit = gasLimit.plus(constants.WORST_CASE_FILL[p.numOutcomes]);
+  }
+  gasLimit = gasLimit.plus(constants.TRADE_GAS_BUFFER);
+  console.log("gasLimit: ", gasLimit.toFixed(), " numTradesPerTx: ", numTradesPerTx);
   console.log("cost:", cost.toFixed(), "wei", speedomatic.unfix(cost, "string"), "eth");
   if (tradeCost.onChainAmount.lt(constants.PRECISION.zero)) {
     console.info("tradeUntilAmountIsZero complete: only dust remaining");
     return p.onSuccess(null);
   }
-
-  var payloadArgs = assign({}, immutableDelete(p, ["doNotCreateOrders", "numTicks", "minPrice", "maxPrice", "sharesProvided"]), {
-    tx: assign({ value: convertBigNumberToHexString(cost) }, p.tx),
-    _loopLimit: convertBigNumberToHexString(3),
+  var tradePayload = assign({}, immutableDelete(p, ["doNotCreateOrders", "numTicks", "minPrice", "maxPrice", "sharesProvided"]), {
+    tx: assign({
+      value: convertBigNumberToHexString(cost),
+      gas: convertBigNumberToHexString(gasLimit),
+    }, p.tx),
+    _loopLimit: convertBigNumberToHexString(numTradesPerTx),
     _fxpAmount: convertBigNumberToHexString(onChainAmount),
     _price: convertBigNumberToHexString(onChainPrice),
+    onSuccess: function (res) {
+      var tickSize = calculateTickSize(p.numTicks, p.minPrice, p.maxPrice);
+      getTradeAmountRemaining({
+        transactionHash: res.hash,
+        startingOnChainAmount: onChainAmount,
+        tickSize: tickSize,
+      }, function (err, tradeOnChainAmountRemaining) {
+        if (err) return p.onFailed(err);
+        console.log("starting amount: ", onChainAmount.toFixed(), "ocs", convertOnChainAmountToDisplayAmount(onChainAmount, tickSize).toFixed(), "shares");
+        console.log("remaining amount:", tradeOnChainAmountRemaining.toFixed(), "ocs", convertOnChainAmountToDisplayAmount(tradeOnChainAmountRemaining, tickSize).toFixed(), "shares");
+        if (tradeOnChainAmountRemaining.eq(onChainAmount)) {
+          if (p.doNotCreateOrders) return p.onSuccess(tradeOnChainAmountRemaining.toFixed());
+          return p.onFailed(new Error("Trade completed but amount of trade unchanged"));
+        }
+        var newAmount = convertOnChainAmountToDisplayAmount(tradeOnChainAmountRemaining, tickSize);
+        var newSharesProvided = newAmount.minus(new BigNumber(displayAmount, 10).minus(new BigNumber(p.sharesProvided, 10)));
+        newSharesProvided = newSharesProvided.lt(0) ? "0" : newSharesProvided.toFixed();
+        tradeUntilAmountIsZero(assign({}, p, {
+          _fxpAmount: newAmount.toFixed(),
+          sharesProvided: newSharesProvided,
+          onSent: noop, // so that p.onSent only fires when the first transaction is sent
+        }));
+      });
+    },
   });
-
-  var tradeOnSuccess = function (res) {
-    var tickSize = calculateTickSize(p.numTicks, p.minPrice, p.maxPrice);
-    getTradeAmountRemaining({
-      transactionHash: res.hash,
-      startingOnChainAmount: onChainAmount,
-      tickSize: tickSize,
-    }, function (err, tradeOnChainAmountRemaining) {
-      if (err) return p.onFailed(err);
-      console.log("starting amount: ", onChainAmount.toFixed(), "ocs", convertOnChainAmountToDisplayAmount(onChainAmount, tickSize).toFixed(), "shares");
-      console.log("remaining amount:", tradeOnChainAmountRemaining.toFixed(), "ocs", convertOnChainAmountToDisplayAmount(tradeOnChainAmountRemaining, tickSize).toFixed(), "shares");
-      if (tradeOnChainAmountRemaining.eq(onChainAmount)) {
-        if (p.doNotCreateOrders) return p.onSuccess(tradeOnChainAmountRemaining.toFixed());
-        return p.onFailed(new Error("Trade completed but amount of trade unchanged"));
-      }
-      var newAmount = convertOnChainAmountToDisplayAmount(tradeOnChainAmountRemaining, tickSize);
-      var newSharesProvided = newAmount.minus(new BigNumber(displayAmount, 10).minus(new BigNumber(p.sharesProvided, 10)));
-      newSharesProvided = newSharesProvided.lt(0) ? "0" : newSharesProvided.toFixed();
-      tradeUntilAmountIsZero(assign({}, p, {
-        _fxpAmount: newAmount.toFixed(),
-        sharesProvided: newSharesProvided,
-        onSent: noop, // so that p.onSent only fires when the first transaction is sent
-      }));
-    });
-  };
-
-  var tradePayload = assign({}, payloadArgs, {onSuccess: tradeOnSuccess});
-  var tradeFunction = p.doNotCreateOrders ? api().Trade.publicFillBestOrderWithLimit : api().Trade.publicTradeWithLimit;
-
-  var estimateGasOnSuccess = function (gasEstimate) {
-    var gasEstimateNumber = new BigNumber(gasEstimate, 16);
-    var bufferedGasEstimate = convertBigNumberToHexString(gasEstimateNumber.plus(constants.GAS_BUFFER));
-    var tradePayloadOnSuccess = assign({}, tradePayload, {tx: assign({}, tradePayload.tx, {gas: bufferedGasEstimate})});
-    tradeFunction(tradePayloadOnSuccess);
-  };
-
-  var estimateGasPayload = assign({}, payloadArgs, {
-    onSent: noop,
-    onSuccess: estimateGasOnSuccess,
-    tx: assign({}, payloadArgs.tx, { estimateGas: true })});
-
-  tradeFunction(estimateGasPayload);
+  if (p.doNotCreateOrders) {
+    api().Trade.publicFillBestOrderWithLimit(tradePayload);
+  } else {
+    api().Trade.publicTradeWithLimit(tradePayload);
+  }
 }
 
 module.exports = tradeUntilAmountIsZero;

--- a/src/trading/trade-until-amount-is-zero.js
+++ b/src/trading/trade-until-amount-is-zero.js
@@ -49,14 +49,14 @@ function tradeUntilAmountIsZero(p) {
   var onChainAmount = tradeCost.onChainAmount;
   var onChainPrice = tradeCost.onChainPrice;
   var cost = tradeCost.cost;
-  var numTradesPerTx = 0;
+  var numTradesPerTx = new BigNumber(0);
   var gasLimit = p.doNotCreateOrders ? new BigNumber(0) : constants.WORST_CASE_PLACE_ORDER[p.numOutcomes];
-  while (gasLimit.plus(constants.WORST_CASE_FILL[p.numOutcomes]) < constants.MAX_GAS_LIMIT_FOR_TRADE && numTradesPerTx < constants.MAX_FILLS_PER_TX) {
-    numTradesPerTx++;
+  while (gasLimit.plus(constants.WORST_CASE_FILL[p.numOutcomes]).lt(constants.MAX_GAS_LIMIT_FOR_TRADE) && numTradesPerTx.lt(constants.MAX_FILLS_PER_TX)) {
+    numTradesPerTx = numTradesPerTx.plus(1);
     gasLimit = gasLimit.plus(constants.WORST_CASE_FILL[p.numOutcomes]);
   }
   gasLimit = gasLimit.plus(constants.TRADE_GAS_BUFFER);
-  console.log("gasLimit: ", gasLimit.toFixed(), " numTradesPerTx: ", numTradesPerTx);
+  console.log("gasLimit: ", gasLimit.toFixed(), " numTradesPerTx: ", numTradesPerTx.toFixed());
   console.log("cost:", cost.toFixed(), "wei", speedomatic.unfix(cost, "string"), "eth");
   if (tradeCost.onChainAmount.lt(constants.PRECISION.zero)) {
     console.info("tradeUntilAmountIsZero complete: only dust remaining");

--- a/src/trading/trade-until-amount-is-zero.js
+++ b/src/trading/trade-until-amount-is-zero.js
@@ -51,7 +51,7 @@ function tradeUntilAmountIsZero(p) {
   var cost = tradeCost.cost;
   var numTradesPerTx = 0;
   var gasLimit = p.doNotCreateOrders ? new BigNumber(0) : constants.WORST_CASE_PLACE_ORDER[p.numOutcomes];
-  while (gasLimit.plus(constants.WORST_CASE_FILL[p.numOutcomes]) < constants.MAX_GAS_LIMIT_FOR_TRADE) {
+  while (gasLimit.plus(constants.WORST_CASE_FILL[p.numOutcomes]) < constants.MAX_GAS_LIMIT_FOR_TRADE && numTradesPerTx < constants.MAX_FILLS_PER_TX) {
     numTradesPerTx++;
     gasLimit = gasLimit.plus(constants.WORST_CASE_FILL[p.numOutcomes]);
   }

--- a/test/unit/trading/place-trade.js
+++ b/test/unit/trading/place-trade.js
@@ -11,6 +11,7 @@ describe("trading/place-trade", function () {
       var placeTrade = proxyquire("../../../src/trading/place-trade", {
         "./get-better-worse-orders": t.mock.getBetterWorseOrders,
         "./trade-until-amount-is-zero": t.mock.tradeUntilAmountIsZero,
+        "../api": t.mock.api,
       });
       placeTrade(Object.assign({}, t.params, {
         onSuccess: function (res) {
@@ -46,6 +47,15 @@ describe("trading/place-trade", function () {
       },
     },
     mock: {
+      api: function () {
+        return {
+          Market: {
+            getNumberOfOutcomes: function (p, callback) {
+              callback(null, 2);
+            },
+          },
+        };
+      },
       getBetterWorseOrders: function (p, callback) {
         assert.deepEqual(p, {
           marketId: "MARKET_ADDRESS",
@@ -100,6 +110,15 @@ describe("trading/place-trade", function () {
       },
     },
     mock: {
+      api: function () {
+        return {
+          Market: {
+            getNumberOfOutcomes: function (p, callback) {
+              callback(null, 2);
+            },
+          },
+        };
+      },
       getBetterWorseOrders: function (p, callback) {
         assert.deepEqual(p, {
           marketId: "MARKET_ADDRESS",

--- a/test/unit/trading/trade-until-amount-is-zero.js
+++ b/test/unit/trading/trade-until-amount-is-zero.js
@@ -42,6 +42,7 @@ describe("trading/trade-until-amount-is-zero", function () {
       sharesProvided: "0",
       _price: "0.5",
       numTicks: "10000",
+      numOutcomes: "2",
       minPrice: "0",
       maxPrice: "1",
       _tradeGroupId: "0x1",
@@ -91,7 +92,7 @@ describe("trading/trade-until-amount-is-zero", function () {
               assert.isFunction(p.onSent);
               assert.isFunction(p.onSuccess);
               assert.isFunction(p.onFailed);
-              assert.strictEqual(p.tx.gas, "0x7a162");
+              assert.strictEqual(p.tx.gas, "0x36dcff");
               p.onSent({ hash: "TRANSACTION_HASH" });
               p.onSuccess({ hash: "TRANSACTION_HASH", value: speedomatic.fix("5", "hex") });
             },
@@ -111,6 +112,7 @@ describe("trading/trade-until-amount-is-zero", function () {
       sharesProvided: "0",
       _price: "0.5",
       numTicks: "10000",
+      numOutcomes: "2",
       minPrice: "0",
       maxPrice: "1",
       _tradeGroupId: "0x1",
@@ -157,7 +159,7 @@ describe("trading/trade-until-amount-is-zero", function () {
               assert.strictEqual(p._fxpAmount, "0x38d7ea4c68000");
               assert.strictEqual(p._price, "0x1388");
               assert.strictEqual(p._tradeGroupId, "0x1");
-              assert.strictEqual(p.tx.gas, "0x7a162");
+              assert.strictEqual(p.tx.gas, "0x36dcff");
               assert.isFunction(p.onSent);
               assert.isFunction(p.onSuccess);
               assert.isFunction(p.onFailed);
@@ -180,6 +182,7 @@ describe("trading/trade-until-amount-is-zero", function () {
       sharesProvided: "0",
       _price: "0.5",
       numTicks: "10000",
+      numOutcomes: "2",
       minPrice: "0",
       maxPrice: "1",
       _tradeGroupId: "0x1",
@@ -226,7 +229,7 @@ describe("trading/trade-until-amount-is-zero", function () {
               assert.strictEqual(p._fxpAmount, "0x38d7ea4c68000");
               assert.strictEqual(p._price, "0x1388");
               assert.strictEqual(p._tradeGroupId, "0x1");
-              assert.strictEqual(p.tx.gas, "0x7a162");
+              assert.strictEqual(p.tx.gas, "0x36dcff");
               assert.isFunction(p.onSent);
               assert.isFunction(p.onSuccess);
               assert.isFunction(p.onFailed);
@@ -249,6 +252,7 @@ describe("trading/trade-until-amount-is-zero", function () {
       sharesProvided: "0",
       _price: "0.5",
       numTicks: "10000",
+      numOutcomes: "2",
       minPrice: "0",
       maxPrice: "1",
       _tradeGroupId: "0x1",
@@ -317,6 +321,7 @@ describe("trading/trade-until-amount-is-zero", function () {
       sharesProvided: "0",
       _price: "0.5",
       numTicks: "10000",
+      numOutcomes: "2",
       minPrice: "0",
       maxPrice: "1",
       _tradeGroupId: "0x1",
@@ -385,6 +390,7 @@ describe("trading/trade-until-amount-is-zero", function () {
       sharesProvided: "0",
       _price: "0.5",
       numTicks: "10000",
+      numOutcomes: "2",
       minPrice: "0",
       maxPrice: "1",
       _tradeGroupId: "0x1",
@@ -467,6 +473,7 @@ describe("trading/trade-until-amount-is-zero", function () {
       sharesProvided: "0",
       _price: "0.5",
       numTicks: "10000",
+      numOutcomes: "2",
       minPrice: "0",
       maxPrice: "1",
       _tradeGroupId: "0x1",
@@ -535,6 +542,7 @@ describe("trading/trade-until-amount-is-zero", function () {
       sharesProvided: "0",
       _price: "0.5",
       numTicks: "10000",
+      numOutcomes: "2",
       minPrice: "0",
       maxPrice: "1",
       _tradeGroupId: "0x1",
@@ -603,6 +611,7 @@ describe("trading/trade-until-amount-is-zero", function () {
       sharesProvided: "0",
       _price: "0.5",
       numTicks: "10000",
+      numOutcomes: "2",
       minPrice: "0",
       maxPrice: "1",
       _tradeGroupId: "0x1",
@@ -671,6 +680,7 @@ describe("trading/trade-until-amount-is-zero", function () {
       sharesProvided: "5",
       _price: "0.5",
       numTicks: "10000",
+      numOutcomes: "2",
       minPrice: "0",
       maxPrice: "1",
       _tradeGroupId: "0x1",
@@ -717,7 +727,7 @@ describe("trading/trade-until-amount-is-zero", function () {
               assert.strictEqual(p._fxpAmount, "0x38d7ea4c68000");
               assert.strictEqual(p._price, "0x1388");
               assert.strictEqual(p._tradeGroupId, "0x1");
-              assert.strictEqual(p.tx.gas, "0x7a162");
+              assert.strictEqual(p.tx.gas, "0x36dcff");
               assert.isFunction(p.onSent);
               assert.isFunction(p.onSuccess);
               assert.isFunction(p.onFailed);


### PR DESCRIPTION
This alters the trading logic to use hardcoded worst case gas costs for trading by market num outcomes.

We set a maximum tx gas limit and number of fills and build up the tx until we cross either amount, starting with the worst case gas cost to make an order (if applicable) and repeatedly adding the worst case gas cost to fill an order.

This means for something like a binary market just filling normal orders we'll hit the tx limit and spend ~2.5 mil gas to take 3 orders.

For an 8 categorical pathological trade (reversing positions from a short to a long) we'll hit the gas limit maximum and end up just taking 1 order and spending 2.3 - 3 mil gas.

TXs that enable creating an order add on worst case gas cost for that as well.

The constants come form new tests added to the augur-core repo which create pathological cases and record gas usage.

In the future we can probably make this better at doing heuristic estimation by looking at the taker data.