### PR TITLE
always try to do at least one trade

### DIFF
--- a/src/trading/trade-until-amount-is-zero.js
+++ b/src/trading/trade-until-amount-is-zero.js
@@ -49,8 +49,9 @@ function tradeUntilAmountIsZero(p) {
   var onChainAmount = tradeCost.onChainAmount;
   var onChainPrice = tradeCost.onChainPrice;
   var cost = tradeCost.cost;
-  var numTradesPerTx = new BigNumber(0);
-  var gasLimit = p.doNotCreateOrders ? new BigNumber(0) : constants.WORST_CASE_PLACE_ORDER[p.numOutcomes];
+  var numTradesPerTx = new BigNumber(1);
+  var orderCreationCost = p.doNotCreateOrders ? new BigNumber(0) : constants.WORST_CASE_PLACE_ORDER[p.numOutcomes];
+  var gasLimit = orderCreationCost.plus(constants.WORST_CASE_FILL[p.numOutcomes]);
   while (gasLimit.plus(constants.WORST_CASE_FILL[p.numOutcomes]).lt(constants.MAX_GAS_LIMIT_FOR_TRADE) && numTradesPerTx.lt(constants.MAX_FILLS_PER_TX)) {
     numTradesPerTx = numTradesPerTx.plus(1);
     gasLimit = gasLimit.plus(constants.WORST_CASE_FILL[p.numOutcomes]);


### PR DESCRIPTION
The "withLimit" trade functions have irregular behavior when they are prevented from actually filling orders.