### PR TITLE
allow passing in numTick array in ###,### format

### DIFF
--- a/scripts/flash/get-payout-numerators.js
+++ b/scripts/flash/get-payout-numerators.js
@@ -11,6 +11,9 @@ function createBigNumber(n) {
 }
 
 function getPayoutNumerators(market, selectedOutcome, invalid) {
+  if (selectedOutcome.indexOf(",") !== -1) {
+    return selectedOutcome.split(",").map(function (x) { return new BigNumber(x); });
+  }
   var maxPrice = createBigNumber(market.maxPrice);
   var minPrice = createBigNumber(market.minPrice);
   var numTicks = createBigNumber(market.numTicks);


### PR DESCRIPTION
This change is to make setting nonsensical report easier.

https://app.clubhouse.io/augur/story/14054/ui-display-for-binary-cat-markets-that-receive-nonsensical-reports