### PR TITLE
neeed to use toString() some places in flash scripts use number inste…

### DIFF
--- a/scripts/flash/get-payout-numerators.js
+++ b/scripts/flash/get-payout-numerators.js
@@ -11,7 +11,7 @@ function createBigNumber(n) {
 }
 
 function getPayoutNumerators(market, selectedOutcome, invalid) {
-  if (selectedOutcome.indexOf(",") !== -1) {
+  if (selectedOutcome.toString().indexOf(",") !== -1) {
     return selectedOutcome.split(",").map(function (x) { return new BigNumber(x); });
   }
   var maxPrice = createBigNumber(market.maxPrice);


### PR DESCRIPTION
…ad of string


Found issue when trying to dispute using malformed outcome payout numerators. 