### PR TITLE
Change getAllAugurLogs behavior to include callbacks, even for empty …

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -232,6 +232,9 @@ export interface RpcInterface {
   setDebugOptions(debugOptions: {[debugOptionName: string]: boolean}): void;
 }
 
+export type BlockRange = { fromBlock: number; toBlock: number };
+export type BatchCallback = (logs: Array<FormattedEventLog>, blockRange: BlockRange) => void;
+
 export class Augur {
   public version: string;
   public options: AugurJsOptions;
@@ -257,7 +260,7 @@ export class Augur {
     [functionName: string]: ApiFunction,
   };
   public events: {
-    getAllAugurLogs: (p: ApiParams, batchCallback: ApiCallback, finalCallback: (err: Error|null) => void) => any;
+    getAllAugurLogs: (p: ApiParams, batchCallback: BatchCallback, finalCallback: (err: Error|null) => void) => any;
     startBlockListeners(blockCallbacks: BlockSubscriptionCallbacks): boolean;
     stopBlockListeners(): boolean;
     startBlockchainEventListeners(eventCallbacks: EventSubscriptionCallbacksKeyedByContract, startingBlockNumber: number, onSetupComplete?: (err: Error|null) => void): void;

--- a/src/events/get-all-augur-logs.js
+++ b/src/events/get-all-augur-logs.js
@@ -37,7 +37,7 @@ function getAllAugurLogs(p, batchCallback, finalCallback) {
   async.eachSeries(chunkBlocks(fromBlock, toBlock).reverse(), function (chunkOfBlocks, nextChunkOfBlocks) {
     ethrpc.getLogs(assign({}, filterParams, chunkOfBlocks), function (err, logs) {
       if (err) return nextChunkOfBlocks(err);
-      if (!Array.isArray(logs) || !logs.length) return nextChunkOfBlocks(null);
+      if (!Array.isArray(logs)) return nextChunkOfBlocks(null);
       console.log("got", logs.length, "logs in blocks", chunkOfBlocks);
       var batchAugurLogs = logs.map(function (log) {
         if (log && Array.isArray(log.topics) && log.topics.length) {
@@ -56,7 +56,7 @@ function getAllAugurLogs(p, batchCallback, finalCallback) {
           }
         }
       });
-      batchCallback(batchAugurLogs);
+      batchCallback(batchAugurLogs, chunkOfBlocks);
       nextChunkOfBlocks(null);
     });
   }, function (err) {

--- a/test/unit/events/get-all-augur-logs.js
+++ b/test/unit/events/get-all-augur-logs.js
@@ -17,8 +17,8 @@ describe("events/get-all-augur-logs", function () {
         "../rpc-interface": t.stub.rpcInterface,
         "../utils/chunk-blocks": chunkBlocks,
       });
-      var processBatchLogs = sinon.spy(function (batchAugurLogs) {
-        t.assertions(batchAugurLogs, processBatchLogs.callCount);
+      var processBatchLogs = sinon.spy(function (batchAugurLogs, chunkOfBlocks) {
+        t.assertions(batchAugurLogs, chunkOfBlocks, processBatchLogs.callCount);
       });
       getAllAugurLogs(t.params, processBatchLogs, function (err) {
         assert.equal(processBatchLogs.callCount, 2);
@@ -124,7 +124,7 @@ describe("events/get-all-augur-logs", function () {
         },
       },
     },
-    assertions: function (batchAugurLogs, callCount) {
+    assertions: function (batchAugurLogs, chunkOfBlocks, callCount) {
       switch (callCount) {
         case 1:
           assert.deepEqual(batchAugurLogs, [
@@ -141,6 +141,10 @@ describe("events/get-all-augur-logs", function () {
               contractName: "TestContractName",
               eventName: "TestEventName",
             }]);
+          assert.deepEqual(chunkOfBlocks, {
+            fromBlock: 10,
+            toBlock: 10,
+          });
           break;
         case 2:
           assert.deepEqual(batchAugurLogs, [{
@@ -168,6 +172,10 @@ describe("events/get-all-augur-logs", function () {
             contractName: "TestContractName",
             eventName: "TestEventName",
           }]);
+          assert.deepEqual(chunkOfBlocks, {
+            fromBlock: 11,
+            toBlock: 21,
+          });
           break;
         default:
           assert.fail();


### PR DESCRIPTION
…getLogs.

This will allow us to check if those blocks are 'null' and infer we have a parity warp problem

This change will be a two parter. First is to get augur.js, which calls back batches of logs, to start calling back the range of blocks it has processed, even if there were no logs in it. This is because parity will sometimes lie about logs not being present when it is in "warp" mode, so we if we just query for the blocks (which will return `null` if it is in this state) we will be able to infer we are impacted by this issue.