### PR TITLE
raise log parsing errors instead of continuing and just logging

### DIFF
--- a/src/events/get-all-augur-logs.js
+++ b/src/events/get-all-augur-logs.js
@@ -51,8 +51,8 @@ function getAllAugurLogs(p, batchCallback, finalCallback) {
           try {
             return parseLogMessage(contractName, eventName, log, eventsAbi[contractName][eventName].inputs);
           } catch (exc) {
-            console.error("parseLogMessage error", exc);
             console.log(contractName, eventName, log, eventsAbi[contractName], chunkOfBlocks);
+            throw new Error(exc);
           }
         }
       });


### PR DESCRIPTION
In the event this exception occurs we would effectively just ignore the log. So one could imagine if we somehow hit this case and received for example no topics in our log response data it would just continue processing the other logs and never process the malformed log.

Letting this exception get raised will crash the process and prevent processors from potentially missing a log.