### PR TITLE
issue where augur.js rejects outcome as string, have to parse as int.

### DIFF
--- a/scripts/flash/create-market-order.js
+++ b/scripts/flash/create-market-order.js
@@ -53,7 +53,7 @@ function createMarketOrder(augur, args, auth, callback) {
         sharesProvided: useShares ? amount : "0",
         _direction: direction,
         _market: marketId,
-        _outcome: outcome,
+        _outcome: parseInt(outcome, 10),
         _tradeGroupId: augur.trading.generateTradeGroupId(),
         doNotCreateOrders: false,
         onSent: noop,

--- a/scripts/flash/fill-market-orders.js
+++ b/scripts/flash/fill-market-orders.js
@@ -68,7 +68,7 @@ function fillMarketOrder(augur, args, auth, callback) {
             sharesProvided: "0",
             _direction: direction,
             _market: marketId,
-            _outcome: outcome,
+            _outcome: parseInt(outcome, 10),
             _tradeGroupId: augur.trading.generateTradeGroupId(),
             doNotCreateOrders: true,
             onSent: noop,

--- a/scripts/helpers/fill-market-order.js
+++ b/scripts/helpers/fill-market-order.js
@@ -80,7 +80,7 @@ getPrivateKey(null, function (err, auth) {
                 tickSize: marketInfo.tickSize,
                 _direction: orderType === "sell" ? 0 : 1,
                 _market: marketInfo.id,
-                _outcome: outcomeToFill,
+                _outcome: parseInt(outcomeToFill, 10),
                 _tradeGroupId: 42,
                 doNotCreateOrders: true,
                 onSent: function () {},


### PR DESCRIPTION
found issue where flash fails because outcome is a string, needs to be number.